### PR TITLE
fix(pages): repair broken scan, community detail, and marketing flows

### DIFF
--- a/app/(marketing)/community/[domain]/page.tsx
+++ b/app/(marketing)/community/[domain]/page.tsx
@@ -3,12 +3,26 @@
 import { useState, useEffect } from "react"
 import { useParams } from "next/navigation"
 import Link from "next/link"
+import { toast } from "sonner"
 import { TokenAnalyzer } from "@/components/organisms/token-analyzer"
+import { LayoutPatternsSection } from "@/components/organisms/layout-patterns-section"
+import { MarketingHeader } from "@/components/organisms/marketing-header"
+import { MarketingFooter } from "@/components/organisms/marketing-footer"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { ExternalLink, Download, Share, Code2, Clock, User, Scan, ArrowLeft } from "lucide-react"
+import {
+  ExternalLink,
+  Download,
+  Share,
+  Code2,
+  Clock,
+  User,
+  Scan,
+  ArrowLeft,
+  Zap,
+} from "lucide-react"
 
 interface SiteData {
   domain: string
@@ -17,11 +31,23 @@ interface SiteData {
   favicon: string | null
   popularity: number
   last_scanned: string | null
-  status: "completed" | "scanning" | "failed" | "pending"
+  status: "completed" | "scanning" | "failed" | "pending" | "queued"
   submitted_by: string | null
-  tokenSet: any | null
-  scanHistory: any[] | null
-  layoutDNA: any | null
+  tokenSet: Parameters<typeof TokenAnalyzer>[0]["tokenSet"] | null
+  scanHistory: Array<{
+    version: number
+    changes: string
+    date: string
+    tokenSetId?: string
+  }> | null
+  layoutDNA: Parameters<typeof LayoutPatternsSection>[0]["layoutDNA"] | null
+}
+
+const EXPORT_FORMATS: Record<string, string> = {
+  json: "json",
+  css: "css",
+  tailwind: "tailwind",
+  figma: "figma",
 }
 
 export default function CommunityDetailPage() {
@@ -31,55 +57,101 @@ export default function CommunityDetailPage() {
   const [siteData, setSiteData] = useState<SiteData | null>(null)
   const [loading, setLoading] = useState(true)
 
-  // Fetch site data from API
   useEffect(() => {
     const fetchSite = async () => {
       if (!domain) return
 
       setLoading(true)
       try {
-        const response = await fetch(`/api/community-detail/${encodeURIComponent(domain)}`)
+        const response = await fetch(
+          `/api/community-detail/${encodeURIComponent(domain)}`
+        )
         if (!response.ok) {
-          console.error('Site API error:', response.status)
+          setSiteData(null)
           return
         }
-        const data = await response.json()
-        if (data.error) {
-          console.error('Site error:', data.error)
-          return
-        }
+        const data = (await response.json()) as SiteData
         setSiteData(data)
       } catch (error) {
-        console.error('Failed to fetch site:', error)
+        console.error("Failed to fetch site:", error)
+        setSiteData(null)
       } finally {
         setLoading(false)
       }
     }
 
-    fetchSite()
+    void fetchSite()
   }, [domain])
 
-  const handleExport = (format: string) => {
-    console.log(`Exporting in ${format} format`)
-    // Implement export functionality
+  const handleExport = async (format: string) => {
+    const exportFormat = EXPORT_FORMATS[format] ?? "json"
+
+    try {
+      const response = await fetch("/api/export", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          domain,
+          format: exportFormat,
+          download: true,
+        }),
+      })
+
+      if (!response.ok) {
+        throw new Error("Export failed")
+      }
+
+      const blob = await response.blob()
+      const url = URL.createObjectURL(blob)
+      const anchor = document.createElement("a")
+      anchor.href = url
+      anchor.download = `${domain}-tokens.${exportFormat === "tailwind" ? "js" : exportFormat}`
+      document.body.appendChild(anchor)
+      anchor.click()
+      anchor.remove()
+      URL.revokeObjectURL(url)
+      toast.success(`Exported tokens as ${format.toUpperCase()}`)
+    } catch {
+      toast.error("Export failed. Try scanning this site first.")
+    }
   }
 
-  const handleCopyMCP = () => {
+  const handleShare = async () => {
+    const shareUrl = `${window.location.origin}/community/${encodeURIComponent(domain)}`
+
+    if (navigator.share) {
+      try {
+        await navigator.share({
+          title: `${domain} design tokens`,
+          text: `Design tokens for ${domain} on ContextDS`,
+          url: shareUrl,
+        })
+        return
+      } catch {
+        // Fall through to clipboard copy
+      }
+    }
+
+    await navigator.clipboard.writeText(shareUrl)
+    toast.success("Link copied to clipboard")
+  }
+
+  const handleCopyMCP = async () => {
     const mcpCode = `// Use in Claude Code
 scan_tokens("https://${domain}")
 get_tokens("https://${domain}")
 layout_profile("https://${domain}")`
 
-    navigator.clipboard.writeText(mcpCode)
-    // TODO: Show toast notification
+    await navigator.clipboard.writeText(mcpCode)
+    toast.success("MCP commands copied to clipboard")
   }
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-background flex items-center justify-center">
+      <div className="flex min-h-screen items-center justify-center bg-background">
         <div className="text-center">
-          <div className="w-8 h-8 border-2 border-neutral-200 dark:border-neutral-800 border-t-blue-500 rounded-full animate-spin mx-auto mb-4" />
-          <p className="text-sm text-grep-9">Loading design tokens...</p>
+          <div className="mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-2 border-neutral-200 border-t-blue-500 dark:border-neutral-800" />
+          <p className="text-sm text-muted-foreground">Loading design tokens...</p>
         </div>
       </div>
     )
@@ -87,240 +159,270 @@ layout_profile("https://${domain}")`
 
   if (!siteData) {
     return (
-      <div className="min-h-screen bg-background flex items-center justify-center">
-        <div className="text-center max-w-md">
-          <h1 className="text-2xl font-bold text-foreground mb-2">Site Not Found</h1>
-          <p className="text-grep-9 mb-4">
-            We couldn't find design tokens for {domain}
-          </p>
-          <Link href="/community">
-            <Button>
-              <ArrowLeft className="h-4 w-4 mr-2" />
-              Back to Community
-            </Button>
-          </Link>
+      <>
+        <MarketingHeader currentPage="community" showSearch />
+        <div className="flex min-h-[60vh] items-center justify-center bg-background px-4">
+          <div className="max-w-md text-center">
+            <h1 className="mb-2 text-2xl font-bold text-foreground">Site Not Found</h1>
+            <p className="mb-6 text-muted-foreground">
+              We couldn&apos;t find design tokens for {domain}. Try scanning it first.
+            </p>
+            <div className="flex flex-col justify-center gap-3 sm:flex-row">
+              <Button asChild>
+                <Link href={`/scan?url=${encodeURIComponent(domain)}`}>
+                  <Zap className="mr-2 h-4 w-4" />
+                  Scan {domain}
+                </Link>
+              </Button>
+              <Button variant="outline" asChild>
+                <Link href="/community">
+                  <ArrowLeft className="mr-2 h-4 w-4" />
+                  Back to Community
+                </Link>
+              </Button>
+            </div>
+          </div>
         </div>
-      </div>
+        <MarketingFooter />
+      </>
     )
   }
 
   return (
-    <div className="min-h-screen bg-background">
-      {/* Header */}
-      <header className="border-b border-grep-2">
-        <div className="container mx-auto px-4 py-6">
-          {/* Breadcrumb */}
-          <div className="mb-4">
-            <nav className="flex items-center gap-2 text-sm text-grep-9">
-              <Link href="/" className="hover:text-foreground">Home</Link>
+    <>
+      <MarketingHeader currentPage="community" showSearch />
+
+      <div className="min-h-screen bg-background">
+        <header className="border-b border-border">
+          <div className="container mx-auto px-4 py-6">
+            <nav className="mb-4 flex items-center gap-2 text-sm text-muted-foreground">
+              <Link href="/" className="hover:text-foreground">
+                Home
+              </Link>
               <span>/</span>
-              <Link href="/community" className="hover:text-foreground">Community</Link>
+              <Link href="/community" className="hover:text-foreground">
+                Community
+              </Link>
               <span>/</span>
               <span className="text-foreground">{siteData.domain}</span>
             </nav>
-          </div>
 
-          <div className="flex items-start justify-between">
-            <div className="flex items-center gap-4">
-              {siteData.favicon && (
-                <img
-                  src={siteData.favicon}
-                  alt={`${siteData.domain} favicon`}
-                  className="w-12 h-12 rounded border border-grep-2"
-                />
-              )}
-              <div>
-                <h1 className="text-3xl font-bold text-foreground">{siteData.domain}</h1>
-                <p className="text-grep-9 mt-1">{siteData.title || siteData.description}</p>
-                <div className="flex items-center gap-4 mt-2">
-                  <Badge variant="secondary">
-                    <Scan className="w-3 h-3 mr-1" />
-                    {siteData.status}
-                  </Badge>
-                  {siteData.last_scanned && (
-                    <span className="text-sm text-grep-9">
-                      <Clock className="w-3 h-3 inline mr-1" />
-                      Updated {new Date(siteData.last_scanned).toLocaleDateString()}
-                    </span>
-                  )}
-                  {siteData.submitted_by && (
-                    <span className="text-sm text-grep-9">
-                      <User className="w-3 h-3 inline mr-1" />
-                      Submitted by {siteData.submitted_by}
-                    </span>
-                  )}
+            <div className="flex items-start justify-between gap-4">
+              <div className="flex items-center gap-4">
+                {siteData.favicon && (
+                  <img
+                    src={siteData.favicon}
+                    alt={`${siteData.domain} favicon`}
+                    className="h-12 w-12 rounded border border-border"
+                  />
+                )}
+                <div>
+                  <h1 className="text-3xl font-bold text-foreground">{siteData.domain}</h1>
+                  <p className="mt-1 text-muted-foreground">
+                    {siteData.title || siteData.description}
+                  </p>
+                  <div className="mt-2 flex flex-wrap items-center gap-4">
+                    <Badge variant="secondary">
+                      <Scan className="mr-1 h-3 w-3" />
+                      {siteData.status}
+                    </Badge>
+                    {siteData.last_scanned && (
+                      <span className="text-sm text-muted-foreground">
+                        <Clock className="mr-1 inline h-3 w-3" />
+                        Updated {new Date(siteData.last_scanned).toLocaleDateString()}
+                      </span>
+                    )}
+                    {siteData.submitted_by && (
+                      <span className="text-sm text-muted-foreground">
+                        <User className="mr-1 inline h-3 w-3" />
+                        Submitted by {siteData.submitted_by}
+                      </span>
+                    )}
+                  </div>
                 </div>
               </div>
-            </div>
-            <div className="flex gap-2">
-              <Button variant="outline" size="sm" asChild>
-                <a href={`https://${domain}`} target="_blank" rel="noopener noreferrer">
-                  <ExternalLink className="w-4 h-4 mr-1" />
-                  Visit Site
-                </a>
-              </Button>
-              <Button variant="outline" size="sm">
-                <Share className="w-4 h-4 mr-1" />
-                Share
-              </Button>
+              <div className="flex shrink-0 gap-2">
+                <Button variant="outline" size="sm" asChild>
+                  <a href={`https://${domain}`} target="_blank" rel="noopener noreferrer">
+                    <ExternalLink className="mr-1 h-4 w-4" />
+                    Visit Site
+                  </a>
+                </Button>
+                <Button variant="outline" size="sm" onClick={() => void handleShare()}>
+                  <Share className="mr-1 h-4 w-4" />
+                  Share
+                </Button>
+              </div>
             </div>
           </div>
-        </div>
-      </header>
+        </header>
 
-      <main className="container mx-auto px-4 py-8">
-        <Tabs value={activeTab} onValueChange={setActiveTab}>
-          <TabsList className="grid w-full grid-cols-4">
-            <TabsTrigger value="tokens">Design Tokens</TabsTrigger>
-            <TabsTrigger value="layout">Layout DNA</TabsTrigger>
-            <TabsTrigger value="history">Scan History</TabsTrigger>
-            <TabsTrigger value="usage">Usage</TabsTrigger>
-          </TabsList>
+        <main className="container mx-auto px-4 py-8">
+          <Tabs value={activeTab} onValueChange={setActiveTab}>
+            <TabsList className="grid w-full grid-cols-4">
+              <TabsTrigger value="tokens">Design Tokens</TabsTrigger>
+              <TabsTrigger value="layout">Layout DNA</TabsTrigger>
+              <TabsTrigger value="history">Scan History</TabsTrigger>
+              <TabsTrigger value="usage">Usage</TabsTrigger>
+            </TabsList>
 
-          <TabsContent value="tokens" className="mt-6">
-            {siteData.tokenSet ? (
-              <TokenAnalyzer
-                tokenSet={siteData.tokenSet}
-                layoutDNA={siteData.layoutDNA}
-                onExport={handleExport}
-                onCopyMCP={handleCopyMCP}
-              />
-            ) : (
+            <TabsContent value="tokens" className="mt-6">
+              {siteData.tokenSet ? (
+                <TokenAnalyzer
+                  tokenSet={siteData.tokenSet}
+                  layoutDNA={siteData.layoutDNA}
+                  onExport={handleExport}
+                  onCopyMCP={() => void handleCopyMCP()}
+                />
+              ) : (
+                <Card>
+                  <CardContent className="space-y-4 pt-6 text-center">
+                    <p className="text-muted-foreground">No tokens available yet</p>
+                    <Button asChild>
+                      <Link href={`/scan?url=${encodeURIComponent(domain)}`}>
+                        <Zap className="mr-2 h-4 w-4" />
+                        Scan this site
+                      </Link>
+                    </Button>
+                  </CardContent>
+                </Card>
+              )}
+            </TabsContent>
+
+            <TabsContent value="layout" className="mt-6">
               <Card>
-                <CardContent className="pt-6">
-                  <p className="text-center text-grep-9">No tokens available yet</p>
+                <CardHeader>
+                  <CardTitle>Layout DNA Analysis</CardTitle>
+                  <CardDescription>
+                    Multi-page layout patterns and component archetypes
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <LayoutPatternsSection layoutDNA={siteData.layoutDNA ?? undefined} />
                 </CardContent>
               </Card>
-            )}
-          </TabsContent>
+            </TabsContent>
 
-          <TabsContent value="layout" className="mt-6">
-            <Card>
-              <CardHeader>
-                <CardTitle>Layout DNA Analysis</CardTitle>
-                <CardDescription>
-                  Multi-page layout patterns and component archetypes
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                {siteData.layoutDNA ? (
-                  <pre className="text-xs bg-grep-0 p-4 rounded overflow-auto">
-                    {JSON.stringify(siteData.layoutDNA, null, 2)}
-                  </pre>
-                ) : (
-                  <p className="text-center text-grep-9 py-8">
-                    Layout DNA analysis not available
-                  </p>
-                )}
-              </CardContent>
-            </Card>
-          </TabsContent>
-
-          <TabsContent value="history" className="mt-6">
-            <Card>
-              <CardHeader>
-                <CardTitle>Scan History</CardTitle>
-                <CardDescription>
-                  Track changes and updates to design tokens over time
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                {siteData.scanHistory && siteData.scanHistory.length > 0 ? (
-                  <div className="space-y-4">
-                    {siteData.scanHistory.map((scan: any, index: number) => (
-                      <div key={index} className="flex items-center justify-between p-4 border border-grep-2 rounded-lg">
-                        <div>
-                          <div className="font-medium">Version {scan.version}</div>
-                          <div className="text-sm text-grep-9">{scan.changes}</div>
-                          <div className="text-xs text-grep-9 mt-1">
-                            {new Date(scan.date).toLocaleDateString()} at {new Date(scan.date).toLocaleTimeString()}
+            <TabsContent value="history" className="mt-6">
+              <Card>
+                <CardHeader>
+                  <CardTitle>Scan History</CardTitle>
+                  <CardDescription>
+                    Track changes and updates to design tokens over time
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  {siteData.scanHistory && siteData.scanHistory.length > 0 ? (
+                    <div className="space-y-4">
+                      {siteData.scanHistory.map((scan) => (
+                        <div
+                          key={`${scan.version}-${scan.date}`}
+                          className="flex items-center justify-between rounded-lg border border-border p-4"
+                        >
+                          <div>
+                            <div className="font-medium">Version {scan.version}</div>
+                            <div className="text-sm text-muted-foreground">{scan.changes}</div>
+                            <div className="mt-1 text-xs text-muted-foreground">
+                              {new Date(scan.date).toLocaleString()}
+                            </div>
+                          </div>
+                          <div className="flex gap-2">
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() => void handleExport("json")}
+                            >
+                              <Download className="mr-1 h-4 w-4" />
+                              Export
+                            </Button>
+                            <Button variant="outline" size="sm" asChild>
+                              <Link href={`/site/${encodeURIComponent(domain)}`}>
+                                <Code2 className="mr-1 h-4 w-4" />
+                                View
+                              </Link>
+                            </Button>
                           </div>
                         </div>
-                        <div className="flex gap-2">
-                          <Button variant="outline" size="sm">
-                            <Download className="w-4 h-4 mr-1" />
-                            Export
-                          </Button>
-                          <Button variant="outline" size="sm">
-                            <Code2 className="w-4 h-4 mr-1" />
-                            Compare
-                          </Button>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="py-8 text-center text-muted-foreground">
+                      No scan history available
+                    </p>
+                  )}
+                </CardContent>
+              </Card>
+            </TabsContent>
+
+            <TabsContent value="usage" className="mt-6">
+              <div className="grid gap-6">
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Claude Code Integration</CardTitle>
+                    <CardDescription>
+                      Use these MCP tools in Claude Code to work with this site&apos;s design
+                      tokens
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="space-y-4">
+                      <div>
+                        <h4 className="mb-2 font-medium">Extract Tokens</h4>
+                        <div className="rounded-lg bg-muted p-3 font-mono text-sm">
+                          scan_tokens(&quot;https://{domain}&quot;)
                         </div>
                       </div>
-                    ))}
-                  </div>
-                ) : (
-                  <p className="text-center text-grep-9 py-8">No scan history available</p>
-                )}
-              </CardContent>
-            </Card>
-          </TabsContent>
+                      <div>
+                        <h4 className="mb-2 font-medium">Get Cached Tokens</h4>
+                        <div className="rounded-lg bg-muted p-3 font-mono text-sm">
+                          get_tokens(&quot;https://{domain}&quot;)
+                        </div>
+                      </div>
+                      <div>
+                        <h4 className="mb-2 font-medium">Layout Analysis</h4>
+                        <div className="rounded-lg bg-muted p-3 font-mono text-sm">
+                          layout_profile(&quot;https://{domain}&quot;)
+                        </div>
+                      </div>
+                    </div>
+                    <Button onClick={() => void handleCopyMCP()} className="mt-4">
+                      <Code2 className="mr-2 h-4 w-4" />
+                      Copy MCP Commands
+                    </Button>
+                  </CardContent>
+                </Card>
 
-          <TabsContent value="usage" className="mt-6">
-            <div className="grid gap-6">
-              <Card>
-                <CardHeader>
-                  <CardTitle>Claude Code Integration</CardTitle>
-                  <CardDescription>
-                    Use these MCP tools in Claude Code to work with this site&apos;s design tokens
-                  </CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <div className="space-y-4">
-                    <div>
-                      <h4 className="font-medium mb-2">Extract Tokens</h4>
-                      <div className="bg-grep-0 p-3 rounded-lg font-mono text-sm">
-                        scan_tokens(&quot;https://{domain}&quot;)
-                      </div>
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Export Options</CardTitle>
+                    <CardDescription>
+                      Download tokens in various formats for your design tools
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+                      <Button variant="outline" onClick={() => void handleExport("json")}>
+                        JSON
+                      </Button>
+                      <Button variant="outline" onClick={() => void handleExport("css")}>
+                        CSS Variables
+                      </Button>
+                      <Button variant="outline" onClick={() => void handleExport("tailwind")}>
+                        Tailwind Config
+                      </Button>
+                      <Button variant="outline" onClick={() => void handleExport("figma")}>
+                        Figma Tokens
+                      </Button>
                     </div>
-                    <div>
-                      <h4 className="font-medium mb-2">Get Cached Tokens</h4>
-                      <div className="bg-grep-0 p-3 rounded-lg font-mono text-sm">
-                        get_tokens(&quot;https://{domain}&quot;)
-                      </div>
-                    </div>
-                    <div>
-                      <h4 className="font-medium mb-2">Layout Analysis</h4>
-                      <div className="bg-grep-0 p-3 rounded-lg font-mono text-sm">
-                        layout_profile(&quot;https://{domain}&quot;)
-                      </div>
-                    </div>
-                  </div>
-                  <Button onClick={handleCopyMCP} className="mt-4">
-                    <Code2 className="w-4 h-4 mr-2" />
-                    Copy MCP Commands
-                  </Button>
-                </CardContent>
-              </Card>
+                  </CardContent>
+                </Card>
+              </div>
+            </TabsContent>
+          </Tabs>
+        </main>
+      </div>
 
-              <Card>
-                <CardHeader>
-                  <CardTitle>Export Options</CardTitle>
-                  <CardDescription>
-                    Download tokens in various formats for your design tools
-                  </CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                    <Button variant="outline" onClick={() => handleExport("json")}>
-                      JSON
-                    </Button>
-                    <Button variant="outline" onClick={() => handleExport("css")}>
-                      CSS Variables
-                    </Button>
-                    <Button variant="outline" onClick={() => handleExport("tailwind")}>
-                      Tailwind Config
-                    </Button>
-                    <Button variant="outline" onClick={() => handleExport("figma")}>
-                      Figma Tokens
-                    </Button>
-                  </div>
-                </CardContent>
-              </Card>
-            </div>
-          </TabsContent>
-        </Tabs>
-      </main>
-    </div>
+      <MarketingFooter />
+    </>
   )
 }

--- a/app/(marketing)/community/client.tsx
+++ b/app/(marketing)/community/client.tsx
@@ -379,7 +379,7 @@ export default function CommunityClient() {
 
                     {/* Actions */}
                     <div className="flex gap-2">
-                      <Link href={`/site/${site.domain}`} className="flex-1">
+                      <Link href={`/community/${site.domain}`} className="flex-1">
                         <Button variant="outline" size="sm" className="w-full text-xs">
                           View Tokens
                         </Button>

--- a/app/(marketing)/contact/page.tsx
+++ b/app/(marketing)/contact/page.tsx
@@ -13,10 +13,7 @@ import { MarketingHeader } from "@/components/organisms/marketing-header"
 import { MarketingFooter } from "@/components/organisms/marketing-footer"
 import { Card, CardContent, CardHeader } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Textarea } from "@/components/ui/textarea"
-import { Label } from "@/components/ui/label"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { ContactForm } from "@/components/molecules/contact-form"
 
 export const metadata: Metadata = {
   title: "Contact - ContextDS",
@@ -155,58 +152,7 @@ export default function ContactPage() {
               </p>
             </div>
 
-            <Card className="border-muted">
-              <CardContent className="p-6">
-                <form className="space-y-6">
-                  <div className="grid md:grid-cols-2 gap-4">
-                    <div>
-                      <Label htmlFor="name">Name</Label>
-                      <Input id="name" placeholder="Your name" className="mt-1" />
-                    </div>
-                    <div>
-                      <Label htmlFor="email">Email</Label>
-                      <Input id="email" type="email" placeholder="your.email@example.com" className="mt-1" />
-                    </div>
-                  </div>
-
-                  <div>
-                    <Label htmlFor="subject">Subject</Label>
-                    <Select>
-                      <SelectTrigger className="mt-1">
-                        <SelectValue placeholder="What's this about?" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="support">General Support</SelectItem>
-                        <SelectItem value="sales">Sales & Enterprise</SelectItem>
-                        <SelectItem value="bug">Bug Report</SelectItem>
-                        <SelectItem value="feature">Feature Request</SelectItem>
-                        <SelectItem value="legal">Privacy & Legal</SelectItem>
-                        <SelectItem value="other">Other</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
-
-                  <div>
-                    <Label htmlFor="company">Company (optional)</Label>
-                    <Input id="company" placeholder="Your company name" className="mt-1" />
-                  </div>
-
-                  <div>
-                    <Label htmlFor="message">Message</Label>
-                    <Textarea
-                      id="message"
-                      placeholder="Tell us how we can help..."
-                      className="mt-1 min-h-[120px]"
-                    />
-                  </div>
-
-                  <Button className="w-full bg-blue-600 hover:bg-blue-700">
-                    <Mail className="h-4 w-4 mr-2" />
-                    Send Message
-                  </Button>
-                </form>
-              </CardContent>
-            </Card>
+            <ContactForm />
           </div>
         </section>
 
@@ -249,7 +195,11 @@ export default function ContactPage() {
                   <p className="text-muted-foreground mb-4 text-sm">
                     Join our Discord server for real-time discussions, help, and community support.
                   </p>
-                  <Button variant="outline">Join Discord</Button>
+                  <Button variant="outline" asChild>
+                    <a href="https://discord.gg/contextds" target="_blank" rel="noopener noreferrer">
+                      Join Discord
+                    </a>
+                  </Button>
                 </CardContent>
               </Card>
 
@@ -260,7 +210,15 @@ export default function ContactPage() {
                   <p className="text-muted-foreground mb-4 text-sm">
                     Participate in feature discussions, report issues, and contribute to our roadmap.
                   </p>
-                  <Button variant="outline">View Discussions</Button>
+                  <Button variant="outline" asChild>
+                    <a
+                      href="https://github.com/contextds/contextds/discussions"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      View Discussions
+                    </a>
+                  </Button>
                 </CardContent>
               </Card>
             </div>

--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -6,10 +6,8 @@ import { useEffect, useMemo, useState, Suspense } from "react"
 import { useRouter } from "next/navigation"
 import {
   Palette,
-  Monitor,
-  Sun,
-  Moon
 } from "lucide-react"
+import { ThemeToggle } from "@/components/atoms/theme-toggle"
 import { cn } from "@/lib/utils"
 import { useRealtimeStats } from "@/hooks/use-realtime-stats"
 import { useRealtimeStore } from "@/stores/realtime-store"
@@ -523,7 +521,7 @@ function HomePageContent() {
                   <Link className="text-grep-9 hover:text-foreground" href="/docs">Docs</Link>
                 </div>
                 <div className="max-sm:w-36">
-                  <Link className="text-grep-9 hover:text-foreground" href="/api">API</Link>
+                  <Link className="text-grep-9 hover:text-foreground" href="/docs#api">API</Link>
                 </div>
                 <div className="max-sm:w-36">
                   <Link className="text-grep-9 hover:text-foreground" href="/community">Community</Link>
@@ -542,18 +540,7 @@ function HomePageContent() {
 
               {/* Theme Toggle - Exact Grep.app Style */}
               <div className="absolute right-0 max-sm:bottom-0">
-                <div className="relative flex h-8 w-[96px] items-center justify-between rounded-full border border-grep-2">
-                  <div className="absolute h-8 w-8 rounded-full border border-grep-3" style={{transform: 'translateX(calc(-1px))'}}></div>
-                  <button className="relative z-10 mx-[-1px] flex h-8 w-8 items-center justify-center transition-colors duration-200 text-foreground" aria-label="Switch to system theme">
-                    <Monitor className="h-4 w-4" />
-                  </button>
-                  <button className="relative z-10 mx-[-1px] flex h-8 w-8 items-center justify-center transition-colors duration-200 text-grep-9 hover:text-foreground" aria-label="Switch to light theme">
-                    <Sun className="h-4 w-4" />
-                  </button>
-                  <button className="relative z-10 mx-[-1px] flex h-8 w-8 items-center justify-center transition-colors duration-200 text-grep-9 hover:text-foreground" aria-label="Switch to dark theme">
-                    <Moon className="h-4 w-4" />
-                  </button>
-                </div>
+                <ThemeToggle />
               </div>
             </div>
           </footer>

--- a/app/(marketing)/pricing/page.tsx
+++ b/app/(marketing)/pricing/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from "next"
+import Link from "next/link"
 import { Check, Star, Zap, Users, Building2 } from "lucide-react"
 import { MarketingHeader } from "@/components/organisms/marketing-header"
 import { MarketingFooter } from "@/components/organisms/marketing-footer"
@@ -37,6 +38,7 @@ const plans = [
       "No priority support"
     ],
     cta: "Start free",
+    href: "/scan",
     popular: false
   },
   {
@@ -59,6 +61,7 @@ const plans = [
     ],
     limitations: [],
     cta: "Start Pro trial",
+    href: "/contact?subject=sales",
     popular: true
   },
   {
@@ -81,6 +84,7 @@ const plans = [
     ],
     limitations: [],
     cta: "Contact sales",
+    href: "/contact?subject=sales",
     popular: false
   },
   {
@@ -103,6 +107,7 @@ const plans = [
     ],
     limitations: [],
     cta: "Contact sales",
+    href: "/contact?subject=sales",
     popular: false
   }
 ]
@@ -196,10 +201,11 @@ export default function PricingPage() {
 
                   <CardContent className="pt-0">
                     <Button
-                      className={`w-full mb-6 ${plan.popular ? 'bg-blue-600 hover:bg-blue-700' : ''}`}
+                      className={`w-full mb-6 ${plan.popular ? "bg-blue-600 hover:bg-blue-700" : ""}`}
                       variant={plan.popular ? "default" : "outline"}
+                      asChild
                     >
-                      {plan.cta}
+                      <Link href={plan.href}>{plan.cta}</Link>
                     </Button>
 
                     <div className="space-y-3">
@@ -327,11 +333,11 @@ export default function PricingPage() {
               Start with our free plan and upgrade when you need more power.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Button className="px-8 py-3 bg-blue-600 hover:bg-blue-700">
-                Start free trial
+              <Button className="px-8 py-3 bg-blue-600 hover:bg-blue-700" asChild>
+                <Link href="/scan">Start free trial</Link>
               </Button>
-              <Button variant="outline" className="px-8 py-3">
-                Contact sales
+              <Button variant="outline" className="px-8 py-3" asChild>
+                <Link href="/contact?subject=sales">Contact sales</Link>
               </Button>
             </div>
           </div>

--- a/app/(marketing)/scan/client.tsx
+++ b/app/(marketing)/scan/client.tsx
@@ -1,153 +1,124 @@
 "use client"
 
-import { useEffect, useState, useCallback, Suspense } from "react"
+import { useCallback, useEffect, useState } from "react"
 import { useSearchParams, useRouter } from "next/navigation"
-import Link from "next/link"
-import { useScanStore, type ScanResult } from "@/stores/scan-store"
-
-// Force dynamic rendering for scan page (uses searchParams)
-export const dynamic = 'force-dynamic'
+import { useScanStore } from "@/stores/scan-store"
 import { useRealtimeStats } from "@/hooks/use-realtime-stats"
 import { useRealtimeStore } from "@/stores/realtime-store"
 import { LiveActivityFeed } from "@/components/molecules/live-activity-feed"
 import { LiveMetricsDashboard } from "@/components/molecules/live-metrics-dashboard"
 import { ScanResultsLayout } from "@/components/organisms/scan-results-layout"
-import { ThemeToggle } from "@/components/atoms/theme-toggle"
-
 import { ProgressiveScanner } from "@/components/organisms/progressive-scanner"
 import { VercelHeader } from "@/components/organisms/vercel-header"
-
 import {
-  Search,
   Zap,
-  BarChart3,
-  Sparkles,
-  ArrowRight,
-  Eye,
-  Palette,
-  Type,
-  Ruler,
   ArrowLeft,
   CheckCircle2,
   AlertCircle,
-  Clock
+  Clock,
 } from "lucide-react"
-
-import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
 import { Separator } from "@/components/ui/separator"
 
 type ViewMode = "scan" | "results"
 
+function normalizeDomain(input: string): string {
+  const trimmed = input.trim()
+  if (!trimmed) return ""
+  try {
+    const url = trimmed.startsWith("http") ? trimmed : `https://${trimmed}`
+    return new URL(url).hostname
+  } catch {
+    return trimmed.replace(/^https?:\/\//, "").split("/")[0] ?? trimmed
+  }
+}
+
 export default function ScanClient() {
   const searchParams = useSearchParams()
   const router = useRouter()
+  const initialUrl = searchParams.get("url") || ""
 
-  // Get initial URL from search params
-  const initialUrl = searchParams.get('url') || ''
-
-  // URL and scan state
   const [url, setUrl] = useState(initialUrl)
-  const [viewMode, setViewMode] = useState<ViewMode>(initialUrl ? "scan" : "scan")
+  const [viewMode, setViewMode] = useState<ViewMode>("scan")
 
-  // Current scan state
-  const [currentScanId, setCurrentScanId] = useState<string | null>(null)
-  const [scanResult, setScanResult] = useState<ScanResult | null>(null)
-
-  // Real-time stats
   const realtimeStats = useRealtimeStats(5000)
-  const { metrics: liveMetrics, isConnected, activities } = useRealtimeStore()
+  const { activities } = useRealtimeStore()
 
-  // Scan store
   const {
-    scans,
     isScanning,
+    result: scanResult,
+    error: scanError,
     startScan,
-    addScanResult,
-    getScanById,
-    clearScanById
+    resetScan,
   } = useScanStore()
 
-  // Start scan on mount if URL provided
-  useEffect(() => {
-    if (initialUrl && !isScanning) {
-      handleScan(initialUrl)
-    }
-  }, [initialUrl])
+  const handleScan = useCallback(
+    async (targetUrl: string) => {
+      const domain = normalizeDomain(targetUrl)
+      if (!domain) return
 
-  // Handle URL scanning
-  const handleScan = useCallback(async (targetUrl: string) => {
-    if (!targetUrl.trim()) return
+      setUrl(domain)
+      setViewMode("scan")
+      resetScan()
 
-    const scanId = Date.now().toString()
-    setCurrentScanId(scanId)
-    setScanResult(null)
-    setViewMode("scan")
-
-    try {
-      await startScan(targetUrl, scanId)
-    } catch (error) {
-      console.error('Scan failed:', error)
-    }
-  }, [startScan])
-
-  // Monitor current scan progress
-  useEffect(() => {
-    if (currentScanId) {
-      const scan = getScanById(currentScanId)
-      if (scan?.result) {
-        setScanResult(scan.result)
-        if (scan.result.status === 'completed' || scan.result.status === 'failed') {
-          setViewMode("results")
-        }
+      try {
+        await startScan(domain)
+      } catch (error) {
+        console.error("Scan failed:", error)
       }
+    },
+    [resetScan, startScan]
+  )
+
+  useEffect(() => {
+    if (initialUrl && !isScanning && !scanResult) {
+      void handleScan(initialUrl)
     }
-  }, [scans, currentScanId, getScanById])
+  }, [initialUrl, isScanning, scanResult, handleScan])
+
+  useEffect(() => {
+    if (scanResult?.status === "completed" || scanResult?.status === "failed") {
+      setViewMode("results")
+    }
+  }, [scanResult])
 
   const handleBack = () => {
     setViewMode("scan")
-    setScanResult(null)
-    setCurrentScanId(null)
-    router.push('/scan')
+    resetScan()
+    router.push("/scan")
   }
 
   const handleNewScan = () => {
     setViewMode("scan")
-    setScanResult(null)
-    setCurrentScanId(null)
-    setUrl('')
+    resetScan()
+    setUrl("")
+    router.push("/scan")
   }
 
   return (
     <div className="flex h-screen w-full flex-col overflow-hidden bg-background">
-      {/* Header */}
-      <VercelHeader
-        currentPage="scan"
-        showSearch={false}
-        isScanning={isScanning}
-      />
+      <VercelHeader currentPage="scan" showSearch={false} isScanning={isScanning} />
 
-      {/* Main Content */}
-      <main className="flex h-[calc(100vh-64px)] w-full flex-col overflow-hidden" id="main-content" role="main" aria-label="Design token scanner">
+      <main
+        className="flex h-[calc(100vh-64px)] w-full flex-col overflow-hidden"
+        id="main-content"
+        role="main"
+        aria-label="Design token scanner"
+      >
         {viewMode === "scan" ? (
           <>
-            {/* Scanner View */}
             <div className="flex flex-1 flex-col items-center justify-center p-6">
-              <div className="w-full max-w-2xl mx-auto text-center space-y-8">
-                {/* Title */}
+              <div className="mx-auto w-full max-w-2xl space-y-8 text-center">
                 <div className="space-y-4">
-                  <h1 className="text-3xl sm:text-4xl font-bold text-foreground">
+                  <h1 className="text-3xl font-bold text-foreground sm:text-4xl">
                     Scan Any Website
                   </h1>
-                  <p className="text-base sm:text-lg text-muted-foreground">
-                    Extract design tokens from any public website. Get colors, typography, spacing, and more in seconds.
+                  <p className="text-base text-muted-foreground sm:text-lg">
+                    Extract design tokens from any public website. Get colors, typography,
+                    spacing, and more in seconds.
                   </p>
                 </div>
 
-                {/* Progressive Scanner */}
                 <ProgressiveScanner
                   onScan={handleScan}
                   initialUrl={url}
@@ -155,103 +126,88 @@ export default function ScanClient() {
                   className="w-full"
                 />
 
-                {/* Live Stats */}
+                {scanError && (
+                  <p className="text-sm text-red-500" role="alert">
+                    {scanError}
+                  </p>
+                )}
+
                 {realtimeStats && (
                   <div className="pt-8">
-                    <LiveMetricsDashboard
-                      layout="horizontal"
-                      className="justify-center"
-                    />
+                    <LiveMetricsDashboard layout="horizontal" className="justify-center" />
                   </div>
                 )}
 
-                {/* Popular Sites */}
                 <div className="pt-8">
-                  <p className="text-sm text-muted-foreground mb-4">Try scanning:</p>
+                  <p className="mb-4 text-sm text-muted-foreground">Try scanning:</p>
                   <div className="flex flex-wrap justify-center gap-2">
-                    {['stripe.com', 'linear.app', 'github.com', 'vercel.com', 'figma.com'].map((site) => (
-                      <button
-                        key={site}
-                        onClick={() => {
-                          setUrl(site)
-                          handleScan(site)
-                        }}
-                        className="px-3 py-1.5 text-sm bg-muted hover:bg-muted/80 rounded-md transition-colors"
-                        disabled={isScanning}
-                      >
-                        {site}
-                      </button>
-                    ))}
+                    {["stripe.com", "linear.app", "github.com", "vercel.com", "figma.com"].map(
+                      (site) => (
+                        <button
+                          key={site}
+                          type="button"
+                          onClick={() => {
+                            setUrl(site)
+                            void handleScan(site)
+                          }}
+                          className="rounded-md bg-muted px-3 py-1.5 text-sm transition-colors hover:bg-muted/80"
+                          disabled={isScanning}
+                        >
+                          {site}
+                        </button>
+                      )
+                    )}
                   </div>
                 </div>
               </div>
             </div>
 
-            {/* Live Activity */}
             {activities.length > 0 && (
               <div className="border-t border-border bg-muted/50 p-6">
-                <div className="max-w-4xl mx-auto">
-                  <LiveActivityFeed compact={true} limit={5} />
+                <div className="mx-auto max-w-4xl">
+                  <LiveActivityFeed compact limit={5} />
                 </div>
               </div>
             )}
           </>
         ) : (
-          <>
-            {/* Results View */}
-            <div className="flex flex-1 flex-col overflow-hidden">
-              {/* Results Header */}
-              <div className="border-b border-border bg-background px-6 py-4">
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-4">
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={handleBack}
-                      className="gap-2"
-                    >
-                      <ArrowLeft className="h-4 w-4" />
-                      Back to Scanner
-                    </Button>
-                    <Separator orientation="vertical" className="h-6" />
-                    <div className="flex items-center gap-2">
-                      {scanResult?.status === 'completed' && (
-                        <CheckCircle2 className="h-4 w-4 text-green-500" />
-                      )}
-                      {scanResult?.status === 'failed' && (
-                        <AlertCircle className="h-4 w-4 text-red-500" />
-                      )}
-                      {scanResult?.status === 'scanning' && (
-                        <Clock className="h-4 w-4 text-blue-500 animate-spin" />
-                      )}
-                      <span className="text-sm font-medium">
-                        {scanResult?.domain || 'Scanning...'}
-                      </span>
-                    </div>
-                  </div>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={handleNewScan}
-                    className="gap-2"
-                  >
-                    <Zap className="h-4 w-4" />
-                    New Scan
+          <div className="flex flex-1 flex-col overflow-hidden">
+            <div className="border-b border-border bg-background px-6 py-4">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-4">
+                  <Button variant="ghost" size="sm" onClick={handleBack} className="gap-2">
+                    <ArrowLeft className="h-4 w-4" />
+                    Back to Scanner
                   </Button>
+                  <Separator orientation="vertical" className="h-6" />
+                  <div className="flex items-center gap-2">
+                    {scanResult?.status === "completed" && (
+                      <CheckCircle2 className="h-4 w-4 text-green-500" />
+                    )}
+                    {scanResult?.status === "failed" && (
+                      <AlertCircle className="h-4 w-4 text-red-500" />
+                    )}
+                    {isScanning && (
+                      <Clock className="h-4 w-4 animate-spin text-blue-500" />
+                    )}
+                    <span className="text-sm font-medium">
+                      {scanResult?.domain || url || "Scanning..."}
+                    </span>
+                  </div>
                 </div>
-              </div>
-
-              {/* Results Content */}
-              <div className="flex-1 overflow-auto">
-                {scanResult && (
-                  <ScanResultsLayout
-                    result={scanResult}
-                    onNewScan={handleNewScan}
-                  />
-                )}
+                <Button variant="outline" size="sm" onClick={handleNewScan} className="gap-2">
+                  <Zap className="h-4 w-4" />
+                  New Scan
+                </Button>
               </div>
             </div>
-          </>
+
+            <div className="flex-1 overflow-auto">
+              {scanResult && (
+                <ScanResultsLayout result={scanResult} onNewScan={handleNewScan} />
+              )}
+            </div>
+          </div>
         )}
       </main>
     </div>

--- a/app/(marketing)/scan/page.tsx
+++ b/app/(marketing)/scan/page.tsx
@@ -1,18 +1,34 @@
 import { Metadata } from "next"
+import { Suspense } from "react"
 import ScanClient from "./client"
 
 export const metadata: Metadata = {
   title: "Scan Website - ContextDS Design Token Scanner",
-  description: "Extract design tokens from any website. Scan for colors, typography, spacing, shadows, and more with AI-powered analysis.",
+  description:
+    "Extract design tokens from any website. Scan for colors, typography, spacing, shadows, and more with AI-powered analysis.",
   openGraph: {
     title: "Scan Website - ContextDS Design Token Scanner",
     description: "Extract design tokens from any website with AI-powered analysis",
   },
 }
 
-// Force dynamic rendering for scan page (uses searchParams)
-export const dynamic = 'force-dynamic'
+export const dynamic = "force-dynamic"
+
+function ScanLoading() {
+  return (
+    <div className="flex h-screen w-full items-center justify-center bg-background">
+      <div className="text-center">
+        <div className="mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-2 border-muted border-t-blue-500" />
+        <p className="text-sm text-muted-foreground">Loading scanner...</p>
+      </div>
+    </div>
+  )
+}
 
 export default function ScanPage() {
-  return <ScanClient />
+  return (
+    <Suspense fallback={<ScanLoading />}>
+      <ScanClient />
+    </Suspense>
+  )
 }

--- a/app/api/community-detail/[domain]/route.ts
+++ b/app/api/community-detail/[domain]/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from "next/server"
+import {
+  getSiteByDomain,
+  getTokenSetsBySiteId,
+  getLayoutProfileBySiteId,
+} from "@/lib/db/queries"
+import {
+  buildLayoutDNAFromProfile,
+  transformTokenSetForAnalyzer,
+} from "@/lib/utils/token-set-transform"
+
+export const dynamic = "force-dynamic"
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ domain: string }> }
+) {
+  try {
+    const { domain: rawDomain } = await params
+    const domain = decodeURIComponent(rawDomain)
+
+    if (!domain) {
+      return NextResponse.json({ error: "Domain is required" }, { status: 400 })
+    }
+
+    if (!process.env.DATABASE_URL) {
+      return NextResponse.json(
+        { error: "Database not available" },
+        { status: 503 }
+      )
+    }
+
+    const site = await getSiteByDomain(domain)
+    if (!site) {
+      return NextResponse.json({ error: "Site not found" }, { status: 404 })
+    }
+
+    const [tokenSets, layoutProfile] = await Promise.all([
+      getTokenSetsBySiteId(site.id),
+      getLayoutProfileBySiteId(site.id),
+    ])
+
+    const latestTokenSet = tokenSets[0] ?? null
+
+    const scanHistory = tokenSets.map((tokenSet) => ({
+      version: tokenSet.versionNumber,
+      changes: `Version ${tokenSet.versionNumber} · ${tokenSet.version}`,
+      date: tokenSet.createdAt.toISOString(),
+      tokenSetId: tokenSet.id,
+    }))
+
+    return NextResponse.json(
+      {
+        domain: site.domain,
+        title: site.title,
+        description: site.description,
+        favicon: site.favicon,
+        popularity: site.popularity,
+        last_scanned: site.lastScanned?.toISOString() ?? null,
+        status: site.status,
+        submitted_by: null,
+        tokenSet: latestTokenSet
+          ? transformTokenSetForAnalyzer(latestTokenSet)
+          : null,
+        scanHistory,
+        layoutDNA: layoutProfile
+          ? buildLayoutDNAFromProfile(layoutProfile)
+          : null,
+      },
+      {
+        headers: {
+          "Cache-Control": "public, max-age=60, stale-while-revalidate=120",
+        },
+      }
+    )
+  } catch (error) {
+    console.error("Community detail API error:", error)
+    return NextResponse.json(
+      { error: "Failed to load site details" },
+      { status: 500 }
+    )
+  }
+}

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,53 @@
+"use client"
+
+import { useEffect } from "react"
+import Link from "next/link"
+import { AlertTriangle, Home, RefreshCw } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { MarketingHeader } from "@/components/organisms/marketing-header"
+import { MarketingFooter } from "@/components/organisms/marketing-footer"
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    console.error("Application error:", error)
+  }, [error])
+
+  return (
+    <>
+      <MarketingHeader showSearch />
+
+      <main className="flex min-h-[70vh] items-center justify-center bg-background px-4">
+        <div className="max-w-lg text-center">
+          <AlertTriangle className="mx-auto mb-4 h-12 w-12 text-amber-500" />
+          <h1 className="mb-4 text-3xl font-bold tracking-tight text-foreground">
+            Something went wrong
+          </h1>
+          <p className="mb-8 text-muted-foreground">
+            An unexpected error occurred. You can try again, or return to the homepage.
+          </p>
+
+          <div className="flex flex-col justify-center gap-3 sm:flex-row">
+            <Button onClick={reset}>
+              <RefreshCw className="mr-2 h-4 w-4" />
+              Try again
+            </Button>
+            <Button variant="outline" asChild>
+              <Link href="/">
+                <Home className="mr-2 h-4 w-4" />
+                Go home
+              </Link>
+            </Button>
+          </div>
+        </div>
+      </main>
+
+      <MarketingFooter />
+    </>
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { SkipLinks } from "@/components/atoms/skip-links";
 import { ErrorBoundary } from "@/components/atoms/error-boundary";
 import { WebVitalsReporter } from "@/components/atoms/web-vitals-reporter";
 import { ComprehensiveSEOTracking } from "@/components/atoms/seo-analytics";
+import { Toaster } from "@/components/ui/sonner";
 import { generateHomepageMetadata } from "@/lib/seo/meta-tags";
 import { generateOrganizationSchema, generateWebsiteSchema, generateSoftwareApplicationSchema } from "@/lib/seo/structured-data";
 import { RESOURCE_HINTS } from "@/lib/seo/performance";
@@ -172,6 +173,7 @@ export default function RootLayout({
         <ErrorBoundary>
           {children}
         </ErrorBoundary>
+        <Toaster richColors closeButton />
       </body>
     </html>
   );

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,51 @@
+import Link from "next/link"
+import { Search, Home, ArrowLeft } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { MarketingHeader } from "@/components/organisms/marketing-header"
+import { MarketingFooter } from "@/components/organisms/marketing-footer"
+
+export default function NotFound() {
+  return (
+    <>
+      <MarketingHeader showSearch />
+
+      <main className="flex min-h-[70vh] items-center justify-center bg-background px-4">
+        <div className="max-w-lg text-center">
+          <p className="mb-2 text-sm font-medium uppercase tracking-wide text-muted-foreground">
+            404
+          </p>
+          <h1 className="mb-4 text-4xl font-bold tracking-tight text-foreground">
+            Page not found
+          </h1>
+          <p className="mb-8 text-muted-foreground">
+            The page you&apos;re looking for doesn&apos;t exist or may have moved. Try scanning a
+            site or browsing the community directory.
+          </p>
+
+          <div className="flex flex-col justify-center gap-3 sm:flex-row">
+            <Button asChild>
+              <Link href="/">
+                <Home className="mr-2 h-4 w-4" />
+                Go home
+              </Link>
+            </Button>
+            <Button variant="outline" asChild>
+              <Link href="/scan">
+                <Search className="mr-2 h-4 w-4" />
+                Scan a site
+              </Link>
+            </Button>
+            <Button variant="ghost" asChild>
+              <Link href="/community">
+                <ArrowLeft className="mr-2 h-4 w-4" />
+                Community
+              </Link>
+            </Button>
+          </div>
+        </div>
+      </main>
+
+      <MarketingFooter />
+    </>
+  )
+}

--- a/components/molecules/contact-form.tsx
+++ b/components/molecules/contact-form.tsx
@@ -1,0 +1,164 @@
+"use client"
+
+import { useState } from "react"
+import { Mail } from "lucide-react"
+import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Card, CardContent } from "@/components/ui/card"
+
+const SUBJECT_EMAILS: Record<string, string> = {
+  support: "support@contextds.com",
+  sales: "sales@contextds.com",
+  bug: "bugs@contextds.com",
+  feature: "features@contextds.com",
+  legal: "legal@contextds.com",
+  other: "support@contextds.com",
+}
+
+export function ContactForm() {
+  const [name, setName] = useState("")
+  const [email, setEmail] = useState("")
+  const [subject, setSubject] = useState("support")
+  const [company, setCompany] = useState("")
+  const [message, setMessage] = useState("")
+  const [submitting, setSubmitting] = useState(false)
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    if (!name.trim() || !email.trim() || !message.trim()) {
+      toast.error("Please fill in your name, email, and message.")
+      return
+    }
+
+    setSubmitting(true)
+
+    try {
+      const response = await fetch("/api/analytics/event", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          event: "contact_form_submitted",
+          properties: {
+            subject,
+            hasCompany: Boolean(company.trim()),
+          },
+        }),
+      })
+
+      if (!response.ok) {
+        throw new Error("Failed to submit")
+      }
+
+      const recipient = SUBJECT_EMAILS[subject] ?? SUBJECT_EMAILS.support
+      const mailtoSubject = encodeURIComponent(
+        `[ContextDS ${subject}] Message from ${name.trim()}`
+      )
+      const mailtoBody = encodeURIComponent(
+        `Name: ${name.trim()}\nEmail: ${email.trim()}${
+          company.trim() ? `\nCompany: ${company.trim()}` : ""
+        }\n\n${message.trim()}`
+      )
+
+      window.location.href = `mailto:${recipient}?subject=${mailtoSubject}&body=${mailtoBody}`
+      toast.success("Opening your email client to send the message.")
+    } catch {
+      toast.error("Something went wrong. Please email support@contextds.com directly.")
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Card className="border-muted">
+      <CardContent className="p-6">
+        <form className="space-y-6" onSubmit={handleSubmit}>
+          <div className="grid gap-4 md:grid-cols-2">
+            <div>
+              <Label htmlFor="name">Name</Label>
+              <Input
+                id="name"
+                placeholder="Your name"
+                className="mt-1"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                required
+              />
+            </div>
+            <div>
+              <Label htmlFor="email">Email</Label>
+              <Input
+                id="email"
+                type="email"
+                placeholder="your.email@example.com"
+                className="mt-1"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                required
+              />
+            </div>
+          </div>
+
+          <div>
+            <Label htmlFor="subject">Subject</Label>
+            <Select value={subject} onValueChange={setSubject}>
+              <SelectTrigger className="mt-1">
+                <SelectValue placeholder="What's this about?" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="support">General Support</SelectItem>
+                <SelectItem value="sales">Sales & Enterprise</SelectItem>
+                <SelectItem value="bug">Bug Report</SelectItem>
+                <SelectItem value="feature">Feature Request</SelectItem>
+                <SelectItem value="legal">Privacy & Legal</SelectItem>
+                <SelectItem value="other">Other</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div>
+            <Label htmlFor="company">Company (optional)</Label>
+            <Input
+              id="company"
+              placeholder="Your company name"
+              className="mt-1"
+              value={company}
+              onChange={(event) => setCompany(event.target.value)}
+            />
+          </div>
+
+          <div>
+            <Label htmlFor="message">Message</Label>
+            <Textarea
+              id="message"
+              placeholder="Tell us how we can help..."
+              className="mt-1 min-h-[120px]"
+              value={message}
+              onChange={(event) => setMessage(event.target.value)}
+              required
+            />
+          </div>
+
+          <Button
+            type="submit"
+            className="w-full bg-blue-600 hover:bg-blue-700"
+            disabled={submitting}
+          >
+            <Mail className="mr-2 h-4 w-4" />
+            {submitting ? "Preparing..." : "Send Message"}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  )
+}

--- a/lib/utils/token-set-transform.ts
+++ b/lib/utils/token-set-transform.ts
@@ -1,0 +1,260 @@
+import type { TokenSet } from "@/lib/db/schema"
+
+type AnalyzerToken = {
+  name: string
+  value: string
+  type: "color" | "typography" | "spacing" | "radius" | "shadow" | "motion"
+  confidence: number
+  usage: number
+  category?: string
+}
+
+type AnalyzerTokenSet = {
+  id: string
+  version: string
+  consensusScore: number
+  tokens: {
+    colors: AnalyzerToken[]
+    typography: AnalyzerToken[]
+    spacing: AnalyzerToken[]
+    radius: AnalyzerToken[]
+    shadows: AnalyzerToken[]
+    motion: AnalyzerToken[]
+  }
+  metadata: {
+    extractedAt: string
+    cssSourceCount: number
+    totalAnalyzed: number
+  }
+}
+
+function emptyTokens() {
+  return {
+    colors: [] as AnalyzerToken[],
+    typography: [] as AnalyzerToken[],
+    spacing: [] as AnalyzerToken[],
+    radius: [] as AnalyzerToken[],
+    shadows: [] as AnalyzerToken[],
+    motion: [] as AnalyzerToken[],
+  }
+}
+
+function mapCategory(category: string): AnalyzerToken["type"] {
+  if (category === "color") return "color"
+  if (category === "typography" || category === "font") return "typography"
+  if (category === "dimension" || category === "spacing") return "spacing"
+  if (category === "radius" || category === "borderRadius") return "radius"
+  if (category === "shadow") return "shadow"
+  if (category === "motion" || category === "duration") return "motion"
+  return "spacing"
+}
+
+function pushToken(
+  tokens: ReturnType<typeof emptyTokens>,
+  category: string,
+  name: string,
+  value: string,
+  confidence = 0.8
+) {
+  const type = mapCategory(category)
+  const token: AnalyzerToken = {
+    name,
+    value,
+    type,
+    confidence,
+    usage: 1,
+    category,
+  }
+
+  switch (type) {
+    case "color":
+      tokens.colors.push(token)
+      break
+    case "typography":
+      tokens.typography.push(token)
+      break
+    case "spacing":
+      tokens.spacing.push(token)
+      break
+    case "radius":
+      tokens.radius.push(token)
+      break
+    case "shadow":
+      tokens.shadows.push(token)
+      break
+    case "motion":
+      tokens.motion.push(token)
+      break
+  }
+}
+
+function fromCurated(curated: Record<string, unknown>): ReturnType<typeof emptyTokens> {
+  const tokens = emptyTokens()
+
+  const colors = curated.colors
+  if (Array.isArray(colors)) {
+    colors.forEach((item, index) => {
+      if (item && typeof item === "object" && "value" in item) {
+        pushToken(
+          tokens,
+          "color",
+          String((item as { name?: string }).name ?? `color-${index + 1}`),
+          String((item as { value: string }).value)
+        )
+      }
+    })
+  }
+
+  const typography = curated.typography as Record<string, unknown> | undefined
+  if (typography) {
+    const families = typography.families
+    if (Array.isArray(families)) {
+      families.forEach((item, index) => {
+        if (typeof item === "string") {
+          pushToken(tokens, "typography", `font-${index + 1}`, item)
+        } else if (item && typeof item === "object" && "value" in item) {
+          pushToken(
+            tokens,
+            "typography",
+            String((item as { name?: string }).name ?? `font-${index + 1}`),
+            String((item as { value: string }).value)
+          )
+        }
+      })
+    }
+    const sizes = typography.sizes
+    if (Array.isArray(sizes)) {
+      sizes.forEach((item, index) => {
+        if (item && typeof item === "object" && "value" in item) {
+          pushToken(
+            tokens,
+            "typography",
+            String((item as { name?: string }).name ?? `size-${index + 1}`),
+            String((item as { value: string }).value)
+          )
+        }
+      })
+    }
+  }
+
+  const spacing = curated.spacing
+  if (Array.isArray(spacing)) {
+    spacing.forEach((item, index) => {
+      if (item && typeof item === "object" && "value" in item) {
+        pushToken(
+          tokens,
+          "spacing",
+          String((item as { name?: string }).name ?? `space-${index + 1}`),
+          String((item as { value: string }).value)
+        )
+      }
+    })
+  }
+
+  const radius = curated.radius
+  if (Array.isArray(radius)) {
+    radius.forEach((item, index) => {
+      if (item && typeof item === "object" && "value" in item) {
+        pushToken(
+          tokens,
+          "radius",
+          String((item as { name?: string }).name ?? `radius-${index + 1}`),
+          String((item as { value: string }).value)
+        )
+      }
+    })
+  }
+
+  const shadows = curated.shadows
+  if (Array.isArray(shadows)) {
+    shadows.forEach((item, index) => {
+      if (item && typeof item === "object" && "value" in item) {
+        pushToken(
+          tokens,
+          "shadow",
+          String((item as { name?: string }).name ?? `shadow-${index + 1}`),
+          String((item as { value: string }).value)
+        )
+      }
+    })
+  }
+
+  return tokens
+}
+
+function fromW3C(tokensJson: Record<string, unknown>): ReturnType<typeof emptyTokens> {
+  const tokens = emptyTokens()
+
+  function walk(node: unknown, path: string[], category: string) {
+    if (!node || typeof node !== "object") return
+
+    const record = node as Record<string, unknown>
+    if ("$value" in record) {
+      pushToken(tokens, category, path.join(".") || category, String(record.$value))
+      return
+    }
+
+    for (const [key, value] of Object.entries(record)) {
+      if (key.startsWith("$")) continue
+      const nextCategory = path.length === 0 ? key : category
+      walk(value, [...path, key], nextCategory)
+    }
+  }
+
+  for (const [category, value] of Object.entries(tokensJson)) {
+    if (category.startsWith("$")) continue
+    walk(value, [category], category)
+  }
+
+  return tokens
+}
+
+export function transformTokenSetForAnalyzer(
+  tokenSet: Pick<TokenSet, "id" | "version" | "consensusScore" | "tokensJson" | "createdAt">
+): AnalyzerTokenSet {
+  const tokensJson = tokenSet.tokensJson as Record<string, unknown>
+  const hasCuratedShape =
+    Array.isArray(tokensJson.colors) ||
+    (tokensJson.typography && typeof tokensJson.typography === "object")
+
+  const tokens = hasCuratedShape ? fromCurated(tokensJson) : fromW3C(tokensJson)
+  const totalAnalyzed = Object.values(tokens).reduce((sum, list) => sum + list.length, 0)
+
+  return {
+    id: tokenSet.id,
+    version: tokenSet.version,
+    consensusScore: Number(tokenSet.consensusScore ?? 0) * 100,
+    tokens,
+    metadata: {
+      extractedAt: tokenSet.createdAt.toISOString(),
+      cssSourceCount: 0,
+      totalAnalyzed,
+    },
+  }
+}
+
+export function buildLayoutDNAFromProfile(profile: {
+  profileJson: unknown
+  containers?: unknown
+  archetypes?: unknown
+  gridFlex?: unknown
+  spacingScale?: unknown
+}) {
+  const profileJson =
+    profile.profileJson && typeof profile.profileJson === "object"
+      ? (profile.profileJson as Record<string, unknown>)
+      : {}
+
+  return {
+    ...profileJson,
+    containers: profile.containers ?? profileJson.containers,
+    archetypes: profile.archetypes ?? profileJson.archetypes,
+    gridSystem: profile.gridFlex ?? profileJson.gridSystem,
+    spacingBase:
+      typeof profile.spacingScale === "object" &&
+      profile.spacingScale &&
+      "base" in (profile.spacingScale as Record<string, unknown>)
+        ? Number((profile.spacingScale as { base: number }).base)
+        : undefined,
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the most broken and stubbed marketing pages identified in the page audit.

### Broken flows repaired
- **`/scan`** — Client now uses the real `useScanStore` API (was calling non-existent `scans`, `getScanById`, etc.). Added Suspense boundary for `useSearchParams`.
- **`/community/[domain]`** — Restored `/api/community-detail/[domain]` API (removed in a prior perf pass). Page now loads site data, shows layout DNA via `LayoutPatternsSection`, and wires export/share/MCP copy with toast feedback.
- **404 / error handling** — Added branded `not-found.tsx` and `error.tsx` with navigation recovery.

### Marketing polish
- **`/contact`** — Working contact form (mailto handoff + analytics event) and real Discord/GitHub links.
- **`/pricing`** — Plan CTAs now link to `/scan` or `/contact`.
- **Homepage** — Footer API link points to `/docs#api`; theme toggle uses the real `ThemeToggle` component.
- **Community directory** — Site cards link to `/community/[domain]` for consistency with the detail page.

### New utilities
- `lib/utils/token-set-transform.ts` — Converts DB token sets (W3C or curated) into `TokenAnalyzer` format.
- Global `Toaster` added to root layout.

## Test plan
- [x] `pnpm build` passes
- [ ] Visit `/scan?url=stripe.com` — scan starts and results render
- [ ] Visit `/community/[domain]` for a known site — tokens and layout tabs load
- [ ] Submit contact form — mailto opens with prefilled message
- [ ] Pricing buttons navigate to `/scan` or `/contact`
- [ ] Visit a bogus URL — branded 404 appears

## Remaining gaps (not in scope)
- Dashboard routes (`/dashboard/*`) — not yet implemented
- Auth pages (`/login`, `/signup`) — not yet implemented
- Stripe checkout integration for paid plans
- Phantom sitemap URLs (`/docs/getting-started`, `/features/layout-dna`, etc.)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f32d3-7c8c-750e-9d6d-6ef4de4aa8b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f32d3-7c8c-750e-9d6d-6ef4de4aa8b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

