### PR TITLE
fix(scanner): harden Docker image and SPA navigation waits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Scanner service local install
+scanner/node_modules/
+scanner/bun.lock

--- a/scanner/.dockerignore
+++ b/scanner/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+bun.lock
+npm-debug.log*
+.git
+*.md
+.env
+.env.*

--- a/scanner/Dockerfile
+++ b/scanner/Dockerfile
@@ -1,19 +1,49 @@
-# Design Contracts accurate scanner — Playwright Chromium in Docker
-# Use with Vercel via SCANNER_SERVICE_URL pointing at this service
-# (Fly.io / Railway / ECS / local docker compose).
-
-FROM mcr.microsoft.com/playwright:v1.52.0-jammy
+# Design Contracts accurate-scan microservice (Playwright Chromium)
+# Deploy alongside Vercel: set SCANNER_SERVICE_URL to this service's HTTPS URL.
+FROM node:22-bookworm-slim
 
 WORKDIR /app
 
+ENV NODE_ENV=production \
+    PORT=4040 \
+    PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    fonts-liberation \
+    libasound2 \
+    libatk-bridge2.0-0 \
+    libatk1.0-0 \
+    libcairo2 \
+    libcups2 \
+    libdbus-1-3 \
+    libdrm2 \
+    libgbm1 \
+    libglib2.0-0 \
+    libgtk-3-0 \
+    libnspr4 \
+    libnss3 \
+    libpango-1.0-0 \
+    libx11-6 \
+    libxcb1 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxext6 \
+    libxfixes3 \
+    libxkbcommon0 \
+    libxrandr2 \
+    wget \
+  && rm -rf /var/lib/apt/lists/*
+
 COPY package.json ./
-RUN npm install --omit=dev
+RUN npm install --omit=dev \
+  && npx playwright install chromium \
+  && rm -rf /root/.npm /tmp/*
 
 COPY server.mjs ./
 
-ENV PORT=4040
-ENV NODE_ENV=production
-
 EXPOSE 4040
+HEALTHCHECK --interval=15s --timeout=5s --retries=5 \
+  CMD node -e "fetch('http://127.0.0.1:4040/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
 
 CMD ["node", "server.mjs"]

--- a/scanner/server.mjs
+++ b/scanner/server.mjs
@@ -26,7 +26,9 @@ async function collectPage(url) {
         'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36 DesignContractsBot/1.0 (+https://designcontracts.sh)',
     })
 
-    await page.goto(url, { waitUntil: 'networkidle', timeout: 45000 })
+    // Prefer domcontentloaded — networkidle hangs on modern SPAs with open sockets.
+    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 })
+    await new Promise((resolve) => setTimeout(resolve, 1500))
 
     const payload = await page.evaluate(() => {
       const sheets = []


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Rebuilds the accurate-scan Docker image on `node:22-bookworm-slim` with Playwright Chromium install (more portable than the previous Playwright base image).
- Adds `scanner/.dockerignore` and ignores local scanner install artifacts.
- Switches Playwright navigation to `domcontentloaded` so modern SPAs no longer hang the scanner on `networkidle`.

## Verification
- Native scanner service: `GET /health` → ok
- `POST /scan` `https://example.com` → completed, 3 CSS sources, screenshot
- `POST /scan` `https://stripe.com` → completed with screenshot
- `docker compose config` validates
- Note: nested cloud agent Docker daemon cannot run containers (overlay mount limitation); compose file + Dockerfile are ready for local/Fly/Railway

## Deploy note
Vercel MCP requires desktop auth in this environment; merge should trigger GitHub→Vercel if the project is still linked.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb424-02cd-75cc-ad48-89813fea64c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb424-02cd-75cc-ad48-89813fea64c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

