### PR TITLE
feat(agent): Design Contract agent via Vercel AI Gateway + AI SDK

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,11 +26,13 @@ SCANNER_SERVICE_URL=http://localhost:4040
 # Optional scanner concurrency limit (default 2)
 # SCANNER_MAX_CONCURRENCY=2
 
-# Optional: AI enrichment via Vercel AI Gateway
+# Vercel AI Gateway — Design Contract agent + enrichment
+# Local: create a key at https://vercel.com/docs/ai-gateway
+# On Vercel: OIDC works without a key
 AI_GATEWAY_API_KEY=
-# or
-# VERCEL_AI_API_KEY=
-# OPENAI_API_KEY=
+# Optional model overrides (provider/model slugs via Gateway)
+# DESIGN_AGENT_MODEL=openai/gpt-5.4-mini
+# DESIGN_FAST_MODEL=openai/gpt-5.4-mini
 
 # Force fast mode only (skip computed CSS / local Playwright fallback)
 # DISABLE_COMPUTED_CSS=1

--- a/app/(marketing)/agent/client.tsx
+++ b/app/(marketing)/agent/client.tsx
@@ -1,0 +1,151 @@
+'use client'
+
+import { useChat } from '@ai-sdk/react'
+import { DefaultChatTransport, isToolUIPart, type UIMessage } from 'ai'
+import { useEffect, useRef, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import type { DesignContractAgentUIMessage } from '@/lib/agent/design-contract-agent'
+import { cn } from '@/lib/utils'
+
+const SUGGESTIONS = [
+  'Scan stripe.com and summarize the design system',
+  'What roles and components are in the vercel.com graph?',
+  'Give me the Design Contract download for example.com after scanning it',
+] as const
+
+function partText(part: UIMessage['parts'][number]): string {
+  if (part.type === 'text' && 'text' in part) return String(part.text || '')
+  return ''
+}
+
+function ToolChip({ part }: { part: UIMessage['parts'][number] }) {
+  if (!isToolUIPart(part)) return null
+  const name = part.type.replace(/^tool-/, '')
+  const state = 'state' in part ? String(part.state) : 'unknown'
+  return (
+    <div className="rounded-lg border border-border/70 bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+      <span className="font-medium text-foreground">{name}</span>
+      <span className="mx-2 text-border">·</span>
+      <span>{state}</span>
+    </div>
+  )
+}
+
+export function AgentChat() {
+  const [input, setInput] = useState('')
+  const bottomRef = useRef<HTMLDivElement>(null)
+
+  const { messages, sendMessage, status, error, stop } = useChat<DesignContractAgentUIMessage>({
+    transport: new DefaultChatTransport({ api: '/api/agent/chat' }),
+  })
+
+  const busy = status === 'submitted' || status === 'streaming'
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [messages, status])
+
+  const onSubmit = (event: React.FormEvent) => {
+    event.preventDefault()
+    const text = input.trim()
+    if (!text || busy) return
+    setInput('')
+    void sendMessage({ text })
+  }
+
+  return (
+    <div className="flex min-h-[60vh] flex-1 flex-col">
+      <div className="flex-1 space-y-5 overflow-y-auto pb-4">
+        {messages.length === 0 ? (
+          <div className="space-y-4 rounded-2xl border border-border/60 bg-card/40 p-6">
+            <p className="text-sm text-muted-foreground">Try one of these:</p>
+            <div className="flex flex-col gap-2">
+              {SUGGESTIONS.map((suggestion) => (
+                <button
+                  key={suggestion}
+                  type="button"
+                  onClick={() => {
+                    setInput(suggestion)
+                    void sendMessage({ text: suggestion })
+                  }}
+                  className="rounded-xl border border-border/60 bg-background px-4 py-3 text-left text-sm text-foreground transition-colors hover:border-foreground/30"
+                >
+                  {suggestion}
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : null}
+
+        {messages.map((message) => (
+          <article
+            key={message.id}
+            className={cn(
+              'rounded-2xl px-4 py-3 text-sm leading-relaxed',
+              message.role === 'user'
+                ? 'ml-8 bg-foreground text-background'
+                : 'mr-4 border border-border/60 bg-card/50 text-foreground'
+            )}
+          >
+            <p className="mb-2 text-[11px] uppercase tracking-[0.18em] opacity-70">
+              {message.role === 'user' ? 'You' : 'Agent'}
+            </p>
+            <div className="space-y-3 whitespace-pre-wrap">
+              {message.parts.map((part, index) => {
+                if (part.type === 'text') {
+                  const text = partText(part)
+                  return text ? <p key={`${message.id}-t-${index}`}>{text}</p> : null
+                }
+                if (isToolUIPart(part)) {
+                  return <ToolChip key={`${message.id}-tool-${index}`} part={part} />
+                }
+                return null
+              })}
+            </div>
+          </article>
+        ))}
+
+        {error ? (
+          <div className="rounded-xl border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+            {error.message || 'Something went wrong talking to the agent.'}
+          </div>
+        ) : null}
+
+        <div ref={bottomRef} />
+      </div>
+
+      <form
+        onSubmit={onSubmit}
+        className="sticky bottom-0 border-t border-border/60 bg-background/95 py-4 backdrop-blur"
+      >
+        <div className="flex gap-2">
+          <input
+            value={input}
+            onChange={(event) => setInput(event.target.value)}
+            placeholder="Scan a site, ask about roles, or request a contract pack…"
+            className="h-11 flex-1 rounded-xl border border-border bg-background px-4 text-sm outline-none ring-offset-background placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
+            disabled={busy}
+          />
+          {busy ? (
+            <Button
+              type="button"
+              variant="outline"
+              className="h-11 rounded-xl"
+              onClick={() => stop()}
+            >
+              Stop
+            </Button>
+          ) : (
+            <Button type="submit" className="h-11 rounded-xl" disabled={!input.trim()}>
+              Send
+            </Button>
+          )}
+        </div>
+        <p className="mt-2 text-xs text-muted-foreground">
+          Tools call your existing scan pipeline. Accurate mode needs{' '}
+          <code className="text-foreground">SCANNER_SERVICE_URL</code>.
+        </p>
+      </form>
+    </div>
+  )
+}

--- a/app/(marketing)/agent/page.tsx
+++ b/app/(marketing)/agent/page.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from 'next'
+import { MarketingFooter } from '@/components/organisms/marketing-footer'
+import { VercelHeader } from '@/components/organisms/vercel-header'
+import { AgentChat } from './client'
+
+export const metadata: Metadata = {
+  title: 'Agent — designcontracts.sh',
+  description:
+    'Chat with the Design Contract agent. Scan sites, inspect semantic graphs, and install AI-ready design packs via Vercel AI Gateway.',
+}
+
+export default function AgentPage() {
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      <VercelHeader currentPage="agent" />
+      <main className="mx-auto flex w-full max-w-3xl flex-1 flex-col px-4 py-10 sm:px-6">
+        <header className="mb-8">
+          <p className="text-sm text-muted-foreground">AI Gateway · ToolLoopAgent</p>
+          <h1 className="mt-2 font-serif text-4xl tracking-tight text-foreground sm:text-5xl">
+            designcontracts.sh
+          </h1>
+          <p className="mt-3 max-w-2xl text-muted-foreground">
+            Ask the agent to scan a site, explain the system graph, or hand you an installable
+            Design Contract pack. Powered by the Vercel AI SDK and AI Gateway.
+          </p>
+        </header>
+        <AgentChat />
+      </main>
+      <MarketingFooter />
+    </div>
+  )
+}

--- a/app/(marketing)/docs/page.tsx
+++ b/app/(marketing)/docs/page.tsx
@@ -84,6 +84,30 @@ npx --yes github:byronwade/Design resolve --request "rebuild the hero"`}
         </section>
 
         <section className="mt-14 space-y-4">
+          <h2 className="text-xl font-semibold text-foreground">Design Contract agent</h2>
+          <p className="text-muted-foreground">
+            Chat with the ToolLoopAgent at{' '}
+            <Link href="/agent" className="text-foreground underline-offset-4 hover:underline">
+              /agent
+            </Link>
+            . It uses the Vercel AI SDK + AI Gateway and tools that call this same scan pipeline (
+            <code className="text-foreground">scan_site</code>,{' '}
+            <code className="text-foreground">get_tokens</code>,{' '}
+            <code className="text-foreground">resolve_graph</code>,{' '}
+            <code className="text-foreground">get_contract_download</code>).
+          </p>
+          <pre className="overflow-x-auto rounded-lg border border-border/60 bg-muted/40 p-4 text-sm">
+            {`POST /api/agent/chat
+{ "messages": [ /* UIMessage[] from useChat */ ] }
+
+# .env.local
+AI_GATEWAY_API_KEY=...
+# optional model override
+DESIGN_AGENT_MODEL=openai/gpt-5.4-mini`}
+          </pre>
+        </section>
+
+        <section className="mt-14 space-y-4">
           <h2 className="text-xl font-semibold text-foreground">MCP</h2>
           <p className="text-muted-foreground">
             Agents can call <code className="text-foreground">scan_tokens</code> and{' '}

--- a/app/(marketing)/features/page.tsx
+++ b/app/(marketing)/features/page.tsx
@@ -31,6 +31,10 @@ const features = [
     body: 'Vercel Blob + Upstash Redis (with memory fallback). No paid Postgres required for the scan path.',
   },
   {
+    title: 'Design Contract agent',
+    body: 'A ToolLoopAgent on Vercel AI Gateway that scans sites, reads the semantic graph, and hands you an installable contract pack via chat.',
+  },
+  {
     title: 'MCP-ready',
     body: 'scan_tokens / get_tokens expose the same curated packs and contract download URLs to Claude Code and other agents.',
   },

--- a/app/api/agent/chat/route.ts
+++ b/app/api/agent/chat/route.ts
@@ -1,0 +1,55 @@
+import { createAgentUIStreamResponse } from 'ai'
+import { type NextRequest, NextResponse } from 'next/server'
+import { designContractAgent } from '@/lib/agent/design-contract-agent'
+import { isAiGatewayConfigured } from '@/lib/ai/gateway'
+import { agentRatelimit } from '@/lib/ratelimit'
+
+export const maxDuration = 60
+export const runtime = 'nodejs'
+
+export async function POST(request: NextRequest) {
+  try {
+    if (!isAiGatewayConfigured()) {
+      return NextResponse.json(
+        {
+          error:
+            'AI Gateway is not configured. Set AI_GATEWAY_API_KEY locally, or deploy on Vercel with OIDC.',
+        },
+        { status: 503 }
+      )
+    }
+
+    const identifier =
+      request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+      request.headers.get('x-real-ip') ||
+      '127.0.0.1'
+
+    const { success } = await agentRatelimit.limit(identifier)
+    if (!success) {
+      return NextResponse.json(
+        { error: 'Rate limit exceeded. Please wait before sending another message.' },
+        { status: 429 }
+      )
+    }
+
+    const body = (await request.json()) as { messages?: unknown }
+    const messages = Array.isArray(body.messages) ? body.messages : null
+    if (!messages || messages.length === 0) {
+      return NextResponse.json({ error: 'messages array is required' }, { status: 400 })
+    }
+
+    return createAgentUIStreamResponse({
+      agent: designContractAgent,
+      uiMessages: messages,
+      abortSignal: request.signal,
+    })
+  } catch (error) {
+    console.error('[agent/chat]', error)
+    return NextResponse.json(
+      {
+        error: error instanceof Error ? error.message : 'Agent chat failed',
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -25,6 +25,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { url: BASE_URL, lastModified: new Date(), changeFrequency: 'daily', priority: 1.0 },
     { url: `${BASE_URL}/scan`, lastModified: new Date(), changeFrequency: 'weekly', priority: 0.9 },
     {
+      url: `${BASE_URL}/agent`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.85,
+    },
+    {
       url: `${BASE_URL}/community`,
       lastModified: new Date(),
       changeFrequency: 'hourly',

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "designer",
       "dependencies": {
         "@ai-sdk/openai": "^4.0.24",
+        "@ai-sdk/react": "^4.0.45",
         "@hookform/resolvers": "^5.2.2",
         "@neondatabase/serverless": "^1.0.2",
         "@projectwallace/css-analyzer": "^7.6.0",
@@ -119,11 +120,15 @@
   "packages": {
     "@ai-sdk/gateway": ["@ai-sdk/gateway@4.0.32", "", { "dependencies": { "@ai-sdk/provider": "4.0.4", "@ai-sdk/provider-utils": "5.0.15", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-U82ZbFEQY80YTyzOEI0jrCjV4Q52uN7/ln/KyI1AvSNR/IX3XwePOfsQWOfDhvmqXkb3TcYbVzWr4p85msKgOw=="],
 
+    "@ai-sdk/mcp": ["@ai-sdk/mcp@2.0.19", "", { "dependencies": { "@ai-sdk/provider": "4.0.4", "@ai-sdk/provider-utils": "5.0.15", "pkce-challenge": "^5.0.1" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-uyMZCn8QWD+12XxjRbJScsJxnPbDFkg00Rv9V+H8jroWjvDkB0Tjek4I03j415KCSrOnIM7kPQ09crQtE94bwg=="],
+
     "@ai-sdk/openai": ["@ai-sdk/openai@4.0.24", "", { "dependencies": { "@ai-sdk/provider": "4.0.4", "@ai-sdk/provider-utils": "5.0.15" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-rCwhBljlo+PPwlPskwb74erKWjcf4psAvvWkQZxkr7YbE+OqhimVzEucRX8fSMtCH+/sEJf6IkWMLEXL3AZErg=="],
 
     "@ai-sdk/provider": ["@ai-sdk/provider@4.0.4", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-tbHKNLirllUNF3ZlkCsXnwab2ZV1Sl4b1H/Cp9ruCce15IBmskE8Gwkk0yo9xDWY+jho2of7lVXtwSsyrq7cwQ=="],
 
     "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.15", "", { "dependencies": { "@ai-sdk/provider": "4.0.4", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8", "undici": "^7.28.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-dnDM4/fS17qO+D7LxVU4003V1+8ZDEWgG7rPhvcDNNFs269qLx+Jnm2mTf72ejyjdzu+f0J+rKNSLXWjZWzxwA=="],
+
+    "@ai-sdk/react": ["@ai-sdk/react@4.0.45", "", { "dependencies": { "@ai-sdk/mcp": "2.0.19", "@ai-sdk/provider": "4.0.4", "@ai-sdk/provider-utils": "5.0.15", "ai": "7.0.42", "swr": "^2.4.1", "throttleit": "2.1.0" }, "peerDependencies": { "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1" } }, "sha512-3pnMqsX/NyfDqIjvM4KIoxYDOm91HxHB2qlSB25laxaEu1CUWz+74H7MRRjcT6hrrkFjEJtsk7h9syDTQXaVnQ=="],
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
@@ -1207,6 +1212,8 @@
 
     "degenerator": ["degenerator@5.0.1", "", { "dependencies": { "ast-types": "^0.13.4", "escodegen": "^2.1.0", "esprima": "^4.0.1" } }, "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ=="],
 
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
@@ -1833,6 +1840,8 @@
 
     "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
     "pkg-dir": ["pkg-dir@4.2.0", "", { "dependencies": { "find-up": "^4.0.0" } }, "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ=="],
 
     "playwright": ["playwright@1.62.1", "", { "dependencies": { "playwright-core": "1.62.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg=="],
@@ -2043,6 +2052,8 @@
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
+    "swr": ["swr@2.4.2", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-ej644Y2bvkIajfR32KGeSSdBXQW+ScjGjkybZgSE7kFpk9eGnV44XY9FJylXi+W75pavSX1PVNB57W5EbhGIYw=="],
+
     "tailwind-merge": ["tailwind-merge@3.6.0", "", {}, "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="],
 
     "tailwindcss": ["tailwindcss@4.3.3", "", {}, "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ=="],
@@ -2144,6 +2155,8 @@
     "use-callback-ref": ["use-callback-ref@1.3.3", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg=="],
 
     "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
+
+    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
     "util": ["util@0.12.5", "", { "dependencies": { "inherits": "^2.0.3", "is-arguments": "^1.0.4", "is-generator-function": "^1.0.7", "is-typed-array": "^1.1.3", "which-typed-array": "^1.1.2" } }, "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA=="],
 

--- a/components/organisms/marketing-footer.tsx
+++ b/components/organisms/marketing-footer.tsx
@@ -6,6 +6,7 @@ const columns = [
     title: 'Product',
     links: [
       { href: '/scan', label: 'Scanner' },
+      { href: '/agent', label: 'Agent' },
       { href: '/community', label: 'Community' },
       { href: '/pricing', label: 'Pricing' },
       { href: '/features', label: 'Features' },

--- a/components/organisms/vercel-header.tsx
+++ b/components/organisms/vercel-header.tsx
@@ -23,6 +23,7 @@ interface VercelHeaderProps {
     | "contact"
     | "privacy"
     | "terms"
+    | "agent"
   showSearch?: boolean
   searchValue?: string
   onSearchChange?: (value: string) => void
@@ -38,6 +39,7 @@ interface VercelHeaderProps {
 
 const NAV = [
   { href: "/scan", label: "Scan" },
+  { href: "/agent", label: "Agent" },
   { href: "/docs", label: "Docs" },
   { href: "/community", label: "Library" },
   { href: "/about", label: "About" },
@@ -135,6 +137,7 @@ export function VercelHeader({
               const active =
                 currentPage === item.label.toLowerCase() ||
                 (item.href === "/scan" && currentPage === "scan") ||
+                (item.href === "/agent" && currentPage === "agent") ||
                 (item.href === "/community" && currentPage === "community")
               return (
                 <Link

--- a/lib/agent/design-contract-agent.ts
+++ b/lib/agent/design-contract-agent.ts
@@ -1,0 +1,40 @@
+/**
+ * Design Contract agent — ToolLoopAgent over Vercel AI Gateway.
+ *
+ * Scans sites, reads cached contracts/graphs, and guides installable packs
+ * for the Design engine (byronwade/Design).
+ */
+
+import { stepCountIs, ToolLoopAgent } from 'ai'
+import { designContractTools } from '@/lib/agent/tools'
+import { agentModel } from '@/lib/ai/gateway'
+
+export const DESIGN_CONTRACT_INSTRUCTIONS = `You are the designcontracts.sh agent.
+
+Your job is to help product designers and AI-native engineers turn public websites into installable Design Contracts — curated tokens, layout DNA, a semantic design graph, DESIGN.md, and a ZIP pack compatible with the Design CLI (npx github:byronwade/Design).
+
+Workflow:
+1. If the user gives a URL/domain, call get_tokens first. If missing, call scan_site (mode=fast unless they ask for accurate/browser capture).
+2. Summarize the system: brand personality, key colors/type/spacing, layout archetypes, and graph highlights.
+3. Offer concrete next steps: download the contract ZIP, skim DESIGN.md, or inspect graph roles/components.
+4. When advising UI rebuilds, ground answers in tool results (tokens, DESIGN.md, graph) — never invent a palette.
+5. Prefer concise, structured answers with markdown. Include download paths and install commands when available.
+
+Rules:
+- Only scan public http(s) sites. Never ask for secrets or private network targets.
+- Prefer get_tokens / get_design_md / resolve_graph over rescanning.
+- If accurate mode fails or is unavailable, fall back to fast and say so.
+- When unsure, call a tool instead of guessing.`
+
+export const designContractAgent = new ToolLoopAgent({
+  id: 'design-contract-agent',
+  model: agentModel(),
+  instructions: DESIGN_CONTRACT_INSTRUCTIONS,
+  tools: designContractTools,
+  stopWhen: stepCountIs(12),
+  temperature: 0.4,
+})
+
+export type DesignContractAgentUIMessage = import('ai').InferAgentUIMessage<
+  typeof designContractAgent
+>

--- a/lib/agent/tools.spec.ts
+++ b/lib/agent/tools.spec.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest'
+import { designContractTools } from '@/lib/agent/tools'
+
+describe('designContractTools', () => {
+  it('exposes the core Design Contract tool surface', () => {
+    expect(Object.keys(designContractTools).sort()).toEqual(
+      ['get_contract_download', 'get_design_md', 'get_tokens', 'resolve_graph', 'scan_site'].sort()
+    )
+  })
+})

--- a/lib/agent/tools.ts
+++ b/lib/agent/tools.ts
@@ -1,0 +1,265 @@
+/**
+ * Design Contract agent tools — wrap the existing scan / store / contract APIs.
+ */
+
+import { tool } from 'ai'
+import { z } from 'zod'
+import { contractDownloadPath, ensureAbsoluteUrl, normalizeDomain } from '@/lib/domain'
+import { getScan, getSite } from '@/lib/storage/serverless-store'
+import { runSimpleScan } from '@/lib/workers/simple-scan'
+
+function slimTokens(tokens: unknown) {
+  if (!tokens || typeof tokens !== 'object') return tokens
+  const curated = tokens as {
+    colors?: unknown[]
+    typography?: { families?: unknown[]; sizes?: unknown[]; weights?: unknown[] }
+    spacing?: unknown[]
+    radius?: unknown[]
+    shadows?: unknown[]
+    motion?: unknown[]
+  }
+  return {
+    colors: (curated.colors || []).slice(0, 16),
+    typography: {
+      families: (curated.typography?.families || []).slice(0, 6),
+      sizes: (curated.typography?.sizes || []).slice(0, 10),
+      weights: (curated.typography?.weights || []).slice(0, 6),
+    },
+    spacing: (curated.spacing || []).slice(0, 12),
+    radius: (curated.radius || []).slice(0, 8),
+    shadows: (curated.shadows || []).slice(0, 6),
+    motion: (curated.motion || []).slice(0, 6),
+  }
+}
+
+export const designContractTools = {
+  scan_site: tool({
+    description:
+      'Scan a public website and produce curated design tokens, layout DNA, a semantic graph, and an installable Design Contract pack. Use when the user provides a URL or asks to extract a design system.',
+    inputSchema: z.object({
+      url: z
+        .string()
+        .describe('Absolute or bare website URL, e.g. stripe.com or https://stripe.com'),
+      mode: z
+        .enum(['fast', 'accurate'])
+        .default('fast')
+        .describe('fast = static CSS; accurate = Docker Playwright when configured'),
+      force: z.boolean().default(false).describe('Bypass the 24h cache and rescan'),
+    }),
+    execute: async ({ url, mode, force }) => {
+      const absolute = ensureAbsoluteUrl(url)
+      const result = await runSimpleScan({
+        url: absolute,
+        mode: mode === 'accurate' && process.env.DISABLE_COMPUTED_CSS !== '1' ? 'accurate' : 'fast',
+        force,
+      })
+
+      return {
+        status: result.cacheHit ? 'cached' : 'fresh',
+        domain: result.domain,
+        url: result.url,
+        summary: result.summary,
+        mode: result.metadata.mode,
+        tokens: slimTokens(result.curatedTokens ?? result.tokens),
+        brand: result.brandAnalysis,
+        layout: {
+          containers: (result.layoutDNA as { containers?: unknown } | undefined)?.containers,
+          breakpoints: (result.layoutDNA as { breakpoints?: unknown } | undefined)?.breakpoints,
+          archetypes: (result.layoutDNA as { archetypes?: unknown } | undefined)?.archetypes,
+        },
+        graph: result.semanticGraph
+          ? {
+              summary: result.semanticGraph.summary,
+              schemaVersion: result.semanticGraph.schemaVersion,
+            }
+          : null,
+        designContract: result.designContract
+          ? {
+              slug: result.designContract.slug,
+              title: result.designContract.title,
+              installCommand: result.designContract.installCommand,
+              summary: result.designContract.summary,
+              download: result.designContract.download || contractDownloadPath(result.domain),
+            }
+          : null,
+        designMdPreview: result.designMd?.markdown?.slice(0, 4000),
+        screenshots: result.screenshots,
+      }
+    },
+  }),
+
+  get_tokens: tool({
+    description:
+      'Retrieve the latest cached design tokens and contract metadata for a domain. Prefer this before scanning when a recent scan may exist.',
+    inputSchema: z.object({
+      domain: z.string().describe('Domain or URL, e.g. stripe.com'),
+    }),
+    execute: async ({ domain }) => {
+      const key = normalizeDomain(domain)
+      const [site, scan] = await Promise.all([getSite(key), getScan(key)])
+      if (!scan) {
+        return {
+          found: false,
+          domain: key,
+          suggestion: `No cached scan for ${key}. Call scan_site with url="${key}".`,
+        }
+      }
+
+      return {
+        found: true,
+        domain: key,
+        site,
+        scannedAt: scan.scannedAt,
+        summary: scan.summary,
+        tokens: slimTokens(scan.curatedTokens ?? scan.tokens),
+        brand: scan.brandAnalysis,
+        graphSummary:
+          scan.semanticGraph && typeof scan.semanticGraph === 'object'
+            ? (scan.semanticGraph as { summary?: unknown }).summary
+            : null,
+        designContract: scan.designContract
+          ? {
+              slug: scan.designContract.slug,
+              title: scan.designContract.title,
+              installCommand: scan.designContract.installCommand,
+              summary: scan.designContract.summary,
+              download: scan.designContract.download || contractDownloadPath(key),
+            }
+          : null,
+      }
+    },
+  }),
+
+  get_design_md: tool({
+    description:
+      'Return DESIGN.md (and optional agent skill markdown) for a scanned domain so you can reason about the system in prose.',
+    inputSchema: z.object({
+      domain: z.string(),
+      includeSkill: z.boolean().default(true),
+    }),
+    execute: async ({ domain, includeSkill }) => {
+      const key = normalizeDomain(domain)
+      const scan = await getScan(key)
+      if (!scan?.designMd) {
+        return {
+          found: false,
+          domain: key,
+          suggestion: `Scan ${key} first with scan_site.`,
+        }
+      }
+
+      return {
+        found: true,
+        domain: key,
+        fileName: scan.designMd.fileName,
+        markdown: scan.designMd.markdown,
+        summary: scan.designMd.summary,
+        skill:
+          includeSkill && scan.designSkill
+            ? {
+                fileName: scan.designSkill.fileName,
+                skillName: scan.designSkill.skillName,
+                description: scan.designSkill.description,
+                markdown: scan.designSkill.markdown,
+              }
+            : null,
+      }
+    },
+  }),
+
+  resolve_graph: tool({
+    description:
+      'Inspect the semantic design graph for a domain — tokens, roles, components, layouts, patterns, and how they connect.',
+    inputSchema: z.object({
+      domain: z.string(),
+      focus: z
+        .enum(['summary', 'roles', 'components', 'patterns', 'tokens'])
+        .default('summary')
+        .describe('Which slice of the graph to return'),
+      limit: z.number().int().min(1).max(40).default(12),
+    }),
+    execute: async ({ domain, focus, limit }) => {
+      const key = normalizeDomain(domain)
+      const scan = await getScan(key)
+      const graph = scan?.semanticGraph as
+        | {
+            summary?: unknown
+            nodes?: Array<{ id?: string; type?: string; label?: string; data?: unknown }>
+            edges?: Array<{ from?: string; to?: string; type?: string }>
+          }
+        | undefined
+
+      if (!graph) {
+        return {
+          found: false,
+          domain: key,
+          suggestion: `No graph for ${key}. Call scan_site first.`,
+        }
+      }
+
+      const nodes = graph.nodes || []
+      const edges = graph.edges || []
+
+      if (focus === 'summary') {
+        return {
+          found: true,
+          domain: key,
+          summary: graph.summary,
+          nodeCount: nodes.length,
+          edgeCount: edges.length,
+        }
+      }
+
+      const typeMap: Record<string, string> = {
+        roles: 'role',
+        components: 'component',
+        patterns: 'pattern',
+        tokens: 'token',
+      }
+      const wanted = typeMap[focus]
+      const filtered = nodes.filter((node) => node.type === wanted).slice(0, limit)
+      const ids = new Set(filtered.map((node) => node.id).filter(Boolean))
+      const relatedEdges = edges
+        .filter((edge) => ids.has(edge.from) || ids.has(edge.to))
+        .slice(0, limit * 3)
+
+      return {
+        found: true,
+        domain: key,
+        focus,
+        nodes: filtered,
+        edges: relatedEdges,
+      }
+    },
+  }),
+
+  get_contract_download: tool({
+    description:
+      'Return the installable Design Contract download URL and install command for a scanned domain.',
+    inputSchema: z.object({
+      domain: z.string(),
+    }),
+    execute: async ({ domain }) => {
+      const key = normalizeDomain(domain)
+      const scan = await getScan(key)
+      if (!scan?.designContract) {
+        return {
+          found: false,
+          domain: key,
+          suggestion: `Scan ${key} first with scan_site.`,
+        }
+      }
+
+      return {
+        found: true,
+        domain: key,
+        download: scan.designContract.download || contractDownloadPath(key),
+        installCommand: scan.designContract.installCommand,
+        slug: scan.designContract.slug,
+        title: scan.designContract.title,
+        summary: scan.designContract.summary,
+        files: (scan.designContract.files || []).map((file) => file.path),
+      }
+    },
+  }),
+}

--- a/lib/ai/gateway.ts
+++ b/lib/ai/gateway.ts
@@ -1,0 +1,31 @@
+/**
+ * Vercel AI Gateway helpers for designcontracts.sh
+ *
+ * AI SDK 7 routes provider/model strings (e.g. "openai/gpt-5.4-mini") through
+ * the Gateway automatically — failover, observability, and cost tracking.
+ * On Vercel, OIDC auth works without AI_GATEWAY_API_KEY; locally set
+ * AI_GATEWAY_API_KEY (https://vercel.com/docs/ai-gateway).
+ */
+
+import { createGateway } from 'ai'
+
+export const DEFAULT_AGENT_MODEL = process.env.DESIGN_AGENT_MODEL?.trim() || 'openai/gpt-5.4-mini'
+
+export const DEFAULT_FAST_MODEL = process.env.DESIGN_FAST_MODEL?.trim() || 'openai/gpt-5.4-mini'
+
+/** Explicit Gateway provider (optional; string models also use Gateway). */
+export const aiGateway = createGateway({
+  apiKey: process.env.AI_GATEWAY_API_KEY,
+})
+
+/** Language model via AI Gateway for ToolLoopAgent / generateText. */
+export function agentModel(modelId: string = DEFAULT_AGENT_MODEL) {
+  return aiGateway(modelId)
+}
+
+/** True when Gateway can authenticate (OIDC on Vercel or explicit API key). */
+export function isAiGatewayConfigured(): boolean {
+  return Boolean(
+    process.env.AI_GATEWAY_API_KEY || process.env.VERCEL_OIDC_TOKEN || process.env.VERCEL
+  )
+}

--- a/lib/ratelimit.ts
+++ b/lib/ratelimit.ts
@@ -2,13 +2,9 @@ import { Ratelimit } from '@upstash/ratelimit'
 import { Redis } from '@upstash/redis'
 
 const redisUrl =
-  process.env.UPSTASH_REDIS_REST_URL ||
-  process.env.REDIS_URL ||
-  process.env.KV_REST_API_URL
+  process.env.UPSTASH_REDIS_REST_URL || process.env.REDIS_URL || process.env.KV_REST_API_URL
 const redisToken =
-  process.env.UPSTASH_REDIS_REST_TOKEN ||
-  process.env.REDIS_TOKEN ||
-  process.env.KV_REST_API_TOKEN
+  process.env.UPSTASH_REDIS_REST_TOKEN || process.env.REDIS_TOKEN || process.env.KV_REST_API_TOKEN
 
 // Development mode - disable rate limiting when Redis isn't configured
 const isDevelopment = !redisUrl || !redisToken || !redisUrl.startsWith('https')
@@ -29,9 +25,9 @@ const mockRatelimit = {
       limit: 1000,
       reset: Date.now() + 60000,
       remaining: 999,
-      pending: Promise.resolve()
+      pending: Promise.resolve(),
     }
-  }
+  },
 }
 
 // Configure rate limiting
@@ -51,6 +47,15 @@ export const scanRatelimit = redis
       limiter: Ratelimit.slidingWindow(5, '1 m'),
       analytics: true,
       prefix: 'contextds:scan',
+    })
+  : mockRatelimit
+
+export const agentRatelimit = redis
+  ? new Ratelimit({
+      redis,
+      limiter: Ratelimit.slidingWindow(20, '1 m'),
+      analytics: true,
+      prefix: 'ratelimit:agent',
     })
   : mockRatelimit
 

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "^4.0.24",
+    "@ai-sdk/react": "^4.0.45",
     "@hookform/resolvers": "^5.2.2",
     "@neondatabase/serverless": "^1.0.2",
     "@projectwallace/css-analyzer": "^7.6.0",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds a Design Contract chat agent built with the Vercel AI SDK (`ToolLoopAgent`, `createAgentUIStreamResponse`, `@ai-sdk/react`) and routed through **Vercel AI Gateway**.

## What’s included
- **`lib/ai/gateway.ts`** — Gateway provider + `agentModel()` / config helpers (`AI_GATEWAY_API_KEY` locally; OIDC on Vercel)
- **`lib/agent/tools.ts`** — Agent tools wrapping the existing scan pipeline:
  - `scan_site`, `get_tokens`, `get_design_md`, `resolve_graph`, `get_contract_download`
- **`lib/agent/design-contract-agent.ts`** — `ToolLoopAgent` with instructions + `stepCountIs(12)`
- **`POST /api/agent/chat`** — streaming UI message response + IP rate limit (20/min)
- **`/agent`** — marketing chat UI (`useChat` + `DefaultChatTransport`)
- Nav / footer / docs / features / sitemap + `.env.example` updates
- Dep: `@ai-sdk/react`

## Config
```bash
# .env.local
AI_GATEWAY_API_KEY=...
# optional
DESIGN_AGENT_MODEL=openai/gpt-5.4-mini
```

## Test plan
- [x] `bun test lib/agent/tools.spec.ts`
- [x] Agent module smoke import (`designContractAgent` tools/id)
- [x] ESLint clean on new agent files
- [ ] Set `AI_GATEWAY_API_KEY` and chat at `/agent` (scan a public domain)
- [ ] Confirm 503 when Gateway is unconfigured
- [ ] Confirm rate limit returns 429 under burst traffic
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb424-02cd-75cc-ad48-89813fea64c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb424-02cd-75cc-ad48-89813fea64c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

