### PR TITLE
feat(ui): full-viewport chat app — home is the product

### DIFF
--- a/app/(marketing)/agent/page.tsx
+++ b/app/(marketing)/agent/page.tsx
@@ -1,15 +1,18 @@
 import { redirect } from 'next/navigation'
 
-type AgentPageProps = {
-  searchParams?: Promise<{ url?: string }> | { url?: string }
-}
+type SearchParams = Promise<{ url?: string | string[] }>
 
-/** Legacy /agent route — Scan is the product name. */
-export default async function AgentPage({ searchParams }: AgentPageProps) {
-  const params = searchParams instanceof Promise ? await searchParams : searchParams
-  const url = params?.url?.trim()
+/** Legacy /agent → home chat */
+export default async function AgentPage({
+  searchParams,
+}: {
+  searchParams: SearchParams
+}) {
+  const params = await searchParams
+  const raw = Array.isArray(params.url) ? params.url[0] : params.url
+  const url = raw?.trim()
   if (url) {
-    redirect(`/scan?url=${encodeURIComponent(url)}`)
+    redirect(`/?url=${encodeURIComponent(url)}`)
   }
-  redirect('/scan')
+  redirect('/')
 }

--- a/app/(marketing)/community/client.tsx
+++ b/app/(marketing)/community/client.tsx
@@ -5,8 +5,7 @@ import Link from 'next/link'
 import { ArrowUp, Clock, ExternalLink, Search, Sparkles } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { MarketingFooter } from '@/components/organisms/marketing-footer'
-import { VercelHeader } from '@/components/organisms/vercel-header'
+import { AppChrome } from '@/components/organisms/app-chrome'
 import { useVotingStore } from '@/stores/voting-store'
 import { cn } from '@/lib/utils'
 
@@ -129,20 +128,16 @@ export default function CommunityClient() {
       />
 
       <div className="relative z-10 flex min-h-screen flex-col">
-        <VercelHeader currentPage="community" showSearch />
+        <AppChrome currentPage="community" />
 
         <main id="main-content" className="flex-1" role="main" aria-label="Design Contracts library">
-          <section className="border-b border-[color:var(--soft-border)] px-4 pb-10 pt-12 sm:px-6 sm:pb-14 sm:pt-16">
+          <section className="border-b border-[color:var(--soft-border)] px-4 pb-8 pt-8 sm:px-6 sm:pb-10 sm:pt-10">
             <div className="mx-auto max-w-5xl">
-              <p className="font-mono text-[11px] uppercase tracking-[0.2em] text-muted-foreground">
+              <h1 className="font-serif text-3xl tracking-tight text-foreground sm:text-4xl">
                 Library
-              </p>
-              <h1 className="mt-3 font-serif text-4xl tracking-tight text-foreground sm:text-5xl">
-                Scanned systems
               </h1>
-              <p className="mt-3 max-w-xl text-muted-foreground">
-                Browse Design Contracts pulled from public sites. Open one, or ask Scan to gather a
-                new system.
+              <p className="mt-2 max-w-xl text-sm text-muted-foreground">
+                Design Contracts from public sites. Open one, or ask chat to gather a new system.
               </p>
 
               <div className="relative mt-8 max-w-xl">
@@ -226,7 +221,7 @@ export default function CommunityClient() {
                       </Button>
                     ) : null}
                     <Button asChild>
-                      <Link href="/scan">Open Scan</Link>
+                      <Link href="/">Open chat</Link>
                     </Button>
                   </div>
                 </div>
@@ -320,7 +315,6 @@ export default function CommunityClient() {
           </section>
         </main>
 
-        <MarketingFooter />
       </div>
     </div>
   )

--- a/app/(marketing)/docs/page.tsx
+++ b/app/(marketing)/docs/page.tsx
@@ -49,8 +49,8 @@ export default function DocsPage() {
           <ol className="list-decimal space-y-3 pl-5 text-muted-foreground">
             <li>
               Open{' '}
-              <Link href="/scan" className="text-foreground underline-offset-4 hover:underline">
-                /scan
+              <Link href="/" className="text-foreground underline-offset-4 hover:underline">
+                chat
               </Link>{' '}
               and paste a public URL (or use the home search).
             </li>
@@ -90,8 +90,8 @@ npx --yes github:byronwade/Design resolve --request "rebuild the hero"`}
           <h2 className="text-xl font-semibold text-foreground">Scan</h2>
           <p className="text-muted-foreground">
             Open{' '}
-            <Link href="/scan" className="text-foreground underline-offset-4 hover:underline">
-              /scan
+            <Link href="/" className="text-foreground underline-offset-4 hover:underline">
+              chat
             </Link>
             . It uses the Vercel AI SDK + AI Gateway (ToolLoopAgent) and tools that call this same
             pipeline (

--- a/app/(marketing)/features/page.tsx
+++ b/app/(marketing)/features/page.tsx
@@ -68,7 +68,7 @@ export default function FeaturesPage() {
 
         <div className="mt-16 flex flex-wrap gap-3">
           <Link
-            href="/scan"
+            href="/"
             className="inline-flex h-11 items-center rounded-md bg-foreground px-5 text-sm font-medium text-background"
           >
             Open Scan

--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -1,187 +1,36 @@
-"use client"
+import type { Metadata } from 'next'
+import { Suspense } from 'react'
+import { AppChrome } from '@/components/organisms/app-chrome'
+import { ScanChat } from './scan/client'
 
-import { Suspense, useState } from "react"
-import { useRouter } from "next/navigation"
-import { ArrowRight } from "lucide-react"
-import { MarketingFooter } from "@/components/organisms/marketing-footer"
-import { VercelHeader } from "@/components/organisms/vercel-header"
-import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
+export const metadata: Metadata = {
+  title: 'Design Contracts',
+  description:
+    'Scan any public site into an installable Design Contract. Chat is the product — paste a URL and get tokens, layout DNA, and an install command.',
+}
 
-const EXAMPLES = ["stripe.com", "linear.app", "vercel.com", "cursor.com"]
-
-function HomePageContent() {
-  const router = useRouter()
-  const [url, setUrl] = useState("")
-
-  const startScan = (value: string) => {
-    const trimmed = value.trim()
-    if (!trimmed) return
-    const domain = trimmed
-      .replace(/^https?:\/\//, "")
-      .replace(/^www\./, "")
-      .split("/")[0]
-    router.push(`/scan?url=${encodeURIComponent(domain)}`)
-  }
-
+function ChatFallback() {
   return (
-    <div className="relative min-h-screen overflow-hidden bg-background text-foreground">
-      {/* Full-bleed atmospheric plane — Vercel dark density */}
-      <div
-        aria-hidden
-        className="pointer-events-none absolute inset-0"
-        style={{
-          background:
-            "radial-gradient(900px 480px at 50% -10%, oklch(0.45 0.04 185 / 0.18), transparent 55%), radial-gradient(700px 500px at 100% 20%, oklch(1 0 0 / 0.04), transparent 45%), linear-gradient(180deg, oklch(0.14 0.006 260) 0%, oklch(0.11 0.005 260) 55%, oklch(0.12 0.005 260) 100%)",
-        }}
-      />
-      <div
-        aria-hidden
-        className="pointer-events-none absolute inset-0 opacity-[0.35] [mask-image:radial-gradient(ellipse_at_center,black_20%,transparent_72%)]"
-        style={{
-          backgroundImage:
-            "linear-gradient(oklch(1 0 0 / 0.04) 1px, transparent 1px), linear-gradient(90deg, oklch(1 0 0 / 0.04) 1px, transparent 1px)",
-          backgroundSize: "64px 64px",
-          animation: "grid-drift 28s linear infinite",
-        }}
-      />
-
-      <div className="relative z-10 flex min-h-screen flex-col">
-        <VercelHeader currentPage="home" showSearch={false} />
-
-        <main
-          id="main-content"
-          className="flex flex-1 flex-col"
-          role="main"
-          aria-label="designcontracts.sh home"
-        >
-          {/* Hero — brand first, one CTA, no cards */}
-          <section className="relative flex min-h-[calc(100svh-4rem)] flex-col justify-center px-4 pb-16 pt-10 sm:px-6">
-            <div className="mx-auto w-full max-w-3xl">
-              <h1 className="animate-slide-in font-serif text-[clamp(3.25rem,9vw,5.75rem)] leading-[0.92] tracking-[-0.03em] text-foreground">
-                designcontracts
-                <span className="font-mono text-[0.55em] tracking-normal text-[oklch(0.78_0.08_185)]">
-                  .sh
-                </span>
-              </h1>
-              <p className="mt-6 max-w-lg animate-fade-in text-base leading-relaxed text-muted-foreground sm:text-lg">
-                Scan any public site into an installable Design Contract — resolve, check, and
-                verify with the Design CLI.
-              </p>
-
-              <form
-                className="mt-10 max-w-xl animate-slide-in"
-                style={{ animationDelay: "80ms" }}
-                onSubmit={(event) => {
-                  event.preventDefault()
-                  startScan(url)
-                }}
-              >
-                <div className="flex flex-col gap-2 border border-[color:var(--soft-border)] bg-background/60 p-1.5 backdrop-blur-md sm:flex-row sm:items-center sm:rounded-lg">
-                  <Input
-                    value={url}
-                    onChange={(event) => setUrl(event.target.value)}
-                    placeholder="stripe.com"
-                    className="h-11 flex-1 rounded-md border-0 bg-transparent text-base shadow-none focus-visible:ring-0"
-                    aria-label="Website URL to scan"
-                  />
-                  <Button
-                    type="submit"
-                    disabled={!url.trim()}
-                    className="h-11 gap-2 rounded-md bg-primary px-5 text-sm font-medium text-primary-foreground hover:opacity-90"
-                  >
-                    Scan site
-                    <ArrowRight className="h-4 w-4" />
-                  </Button>
-                </div>
-              </form>
-
-              <p
-                className="mt-5 animate-fade-in text-sm text-muted-foreground"
-                style={{ animationDelay: "140ms" }}
-              >
-                Try{" "}
-                {EXAMPLES.map((site, index) => (
-                  <span key={site}>
-                    {index > 0 ? (index === EXAMPLES.length - 1 ? ", or " : ", ") : null}
-                    <button
-                      type="button"
-                      onClick={() => startScan(site)}
-                      className="text-foreground/90 underline decoration-[color:var(--soft-border)] underline-offset-4 transition hover:decoration-[oklch(0.78_0.08_185)]"
-                    >
-                      {site}
-                    </button>
-                  </span>
-                ))}
-              </p>
-            </div>
-
-            {/* Dominant product visual — edge-to-edge contract preview plane */}
-            <div
-              aria-hidden
-              className="pointer-events-none absolute inset-x-0 bottom-0 h-[38%] overflow-hidden opacity-50 [mask-image:linear-gradient(to_top,black_10%,transparent_95%)]"
-            >
-              <pre className="mx-auto max-w-5xl px-4 font-mono text-[11px] leading-5 text-muted-foreground sm:text-xs">
-                {`# DESIGN.md — stripe.com
-tokens.color.brand.primary → #635BFF
-tokens.type.display → sohne · 600
-layout.archetype → marketing-hero
-graph.role.cta → component.button.primary
-
-$ npx github:byronwade/Design install stripe-com
-→ resolve · check · verify`}
-              </pre>
-            </div>
-          </section>
-
-          {/* Below fold — one job: what you get */}
-          <section className="border-t border-[color:var(--soft-border)] px-4 py-20 sm:px-6">
-            <div className="mx-auto grid w-full max-w-5xl gap-12 sm:grid-cols-3 sm:gap-8">
-              {[
-                {
-                  title: "Scan-first",
-                  body: "Chat is the surface. Under the hood, Scan calls the pipeline when it needs fresh data.",
-                },
-                {
-                  title: "Inline contracts",
-                  body: "Results land in-chat as a Design Contract widget — open the full page when you need every tab.",
-                },
-                {
-                  title: "Enforced forever",
-                  body: "resolve → check → verify keeps every new component on-brand.",
-                },
-              ].map((item, index) => (
-                <div
-                  key={item.title}
-                  className="animate-fade-in"
-                  style={{ animationDelay: `${index * 60}ms` }}
-                >
-                  <h2 className="text-sm font-medium tracking-tight text-foreground">
-                    {item.title}
-                  </h2>
-                  <p className="mt-2 text-sm leading-relaxed text-muted-foreground">{item.body}</p>
-                </div>
-              ))}
-            </div>
-          </section>
-        </main>
-
-        <MarketingFooter />
-      </div>
+    <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+      Loading…
     </div>
   )
 }
 
 export default function HomePage() {
   return (
-    <Suspense
-      fallback={
-        <div className="flex min-h-screen items-center justify-center bg-background text-muted-foreground">
-          Loading…
-        </div>
-      }
-    >
-      <HomePageContent />
-    </Suspense>
+    <div className="flex h-dvh max-h-dvh flex-col overflow-hidden bg-background text-foreground">
+      <AppChrome currentPage="home" />
+      <main
+        id="main-content"
+        className="flex min-h-0 flex-1 flex-col"
+        role="main"
+        aria-label="Design Contracts chat"
+      >
+        <Suspense fallback={<ChatFallback />}>
+          <ScanChat />
+        </Suspense>
+      </main>
+    </div>
   )
 }

--- a/app/(marketing)/scan/client.tsx
+++ b/app/(marketing)/scan/client.tsx
@@ -12,7 +12,6 @@ import { useSearchParams } from 'next/navigation'
 import {
   Conversation,
   ConversationContent,
-  ConversationEmptyState,
   ConversationScrollButton,
 } from '@/components/ai-elements/conversation'
 import {
@@ -28,7 +27,6 @@ import {
   PromptInputTextarea,
   type PromptInputMessage,
 } from '@/components/ai-elements/prompt-input'
-import { Suggestion, Suggestions } from '@/components/ai-elements/suggestion'
 import {
   Tool,
   ToolContent,
@@ -41,11 +39,13 @@ import {
   isScanResultToolName,
 } from '@/components/molecules/scan-result-widget'
 import type { DesignContractAgentUIMessage } from '@/lib/agent/design-contract-agent'
+import { cn } from '@/lib/utils'
 
-const SUGGESTIONS = [
-  'Scan stripe.com and install the Design Contract',
-  'Pull the design system from linear.app',
-  'Compare type + color on vercel.com',
+const EXAMPLES = [
+  { label: 'stripe.com', prompt: 'Scan stripe.com and install the Design Contract' },
+  { label: 'linear.app', prompt: 'Pull the design system from linear.app' },
+  { label: 'vercel.com', prompt: 'Compare type + color on vercel.com' },
+  { label: 'cursor.com', prompt: 'Scan cursor.com and summarize the Design Contract' },
 ] as const
 
 function partText(part: UIMessage['parts'][number]): string {
@@ -77,11 +77,11 @@ function ToolPart({ part }: { part: UIMessage['parts'][number] }) {
       ({
         domain: inputDomain.replace(/^https?:\/\//, '').split('/')[0] || undefined,
       } as const)
-    return <ScanResultWidget data={payload} state={state} className="mb-2" />
+    return <ScanResultWidget data={payload} state={state} className="mt-1" />
   }
 
   return (
-    <Tool defaultOpen={state === 'output-error'}>
+    <Tool defaultOpen={state === 'output-error'} className="mt-1">
       <ToolHeader
         title={name}
         type={part.type as `tool-${string}`}
@@ -101,6 +101,46 @@ function ToolPart({ part }: { part: UIMessage['parts'][number] }) {
   )
 }
 
+function EmptyState({
+  onPick,
+  disabled,
+}: {
+  onPick: (prompt: string) => void
+  disabled?: boolean
+}) {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center px-4 pb-8 pt-16 animate-fade-in">
+      <h1 className="font-serif text-[clamp(2.5rem,7vw,3.75rem)] leading-[0.95] tracking-[-0.03em] text-foreground">
+        designcontracts
+        <span className="font-mono text-[0.5em] tracking-normal text-[oklch(0.78_0.08_185)]">
+          .sh
+        </span>
+      </h1>
+      <p className="mt-4 max-w-md text-center text-[15px] leading-relaxed text-muted-foreground">
+        Paste a URL. Get an installable Design Contract.
+      </p>
+      <div className="mt-8 flex flex-wrap items-center justify-center gap-2">
+        {EXAMPLES.map((example, index) => (
+          <button
+            key={example.label}
+            type="button"
+            disabled={disabled}
+            onClick={() => onPick(example.prompt)}
+            className={cn(
+              'rounded-md border border-[color:var(--soft-border)] bg-transparent px-3 py-1.5 font-mono text-xs text-muted-foreground transition',
+              'hover:border-foreground/25 hover:text-foreground disabled:opacity-50',
+              'animate-slide-in'
+            )}
+            style={{ animationDelay: `${index * 40}ms` }}
+          >
+            {example.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}
+
 export function ScanChat() {
   const searchParams = useSearchParams()
   const startedUrl = useRef<string | null>(null)
@@ -111,6 +151,7 @@ export function ScanChat() {
   })
 
   const busy = status === 'submitted' || status === 'streaming'
+  const hasMessages = messages.length > 0 || Boolean(searchParams.get('url'))
 
   useEffect(() => {
     const raw = searchParams.get('url')?.trim()
@@ -134,102 +175,137 @@ export function ScanChat() {
   }
 
   return (
-    <div className="relative flex min-h-[65vh] flex-1 flex-col overflow-hidden border border-[color:var(--soft-border)] bg-background/40">
-      <Conversation className="min-h-0 flex-1">
-        <ConversationContent className="gap-6 px-4 py-5 sm:px-5">
-          {messages.length === 0 && !searchParams.get('url') ? (
-            <div className="flex min-h-[40vh] flex-col items-center justify-center gap-5 px-2 text-center">
-              <ConversationEmptyState
-                title="Scan a public site"
-                description="Paste a URL or pick a suggestion. Scan gathers tokens and drops an installable Design Contract inline."
-                className="min-h-0 p-0"
-              />
-              <Suggestions className="w-full max-w-lg justify-center px-1">
-                {SUGGESTIONS.map((suggestion) => (
-                  <Suggestion
-                    key={suggestion}
-                    suggestion={suggestion}
-                    onClick={(value) => void sendMessage({ text: value })}
-                    className="rounded-md"
-                    variant="outline"
-                  />
-                ))}
-              </Suggestions>
-            </div>
-          ) : null}
+    <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
+      {/* Soft atmosphere — not a marketing hero */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0"
+        style={{
+          background:
+            'radial-gradient(720px 360px at 50% 0%, oklch(0.42 0.035 185 / 0.10), transparent 60%)',
+        }}
+      />
 
-          {messages.map((message) => (
-            <Message from={message.role} key={message.id}>
-              <MessageContent>
-                {message.parts.map((part, index) => {
-                  if (part.type === 'text') {
-                    const content = partText(part)
-                    if (!content) return null
-                    return message.role === 'assistant' ? (
-                      <MessageResponse key={`${message.id}-t-${index}`}>
-                        {content}
-                      </MessageResponse>
-                    ) : (
-                      <p key={`${message.id}-t-${index}`} className="whitespace-pre-wrap">
-                        {content}
-                      </p>
-                    )
-                  }
-                  if (isToolUIPart(part)) {
-                    return <ToolPart key={`${message.id}-tool-${index}`} part={part} />
-                  }
-                  return null
-                })}
-              </MessageContent>
-            </Message>
-          ))}
-
-          {error ? (
-            <div className="border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-              {error.message || 'Something went wrong during scan.'}
-            </div>
-          ) : null}
-        </ConversationContent>
-        <ConversationScrollButton />
-      </Conversation>
-
-      <div className="shrink-0 border-t border-[color:var(--soft-border)] bg-background/90 p-3 backdrop-blur sm:p-4">
-        {messages.length > 0 ? (
-          <Suggestions className="mb-3 px-0.5">
-            {SUGGESTIONS.map((suggestion) => (
-              <Suggestion
-                key={suggestion}
-                suggestion={suggestion}
-                onClick={(value) => void sendMessage({ text: value })}
-                className="rounded-md"
-                variant="outline"
+      <div className="relative z-10 flex min-h-0 flex-1 flex-col">
+        <Conversation className="min-h-0 flex-1">
+          <ConversationContent
+            className={cn(
+              'mx-auto w-full max-w-2xl gap-5 px-4 py-6 sm:px-6',
+              !hasMessages && 'flex min-h-full flex-col'
+            )}
+          >
+            {!hasMessages ? (
+              <EmptyState
                 disabled={busy}
+                onPick={(prompt) => void sendMessage({ text: prompt })}
               />
-            ))}
-          </Suggestions>
-        ) : null}
+            ) : null}
 
-        <PromptInput onSubmit={onSubmit} className="border-[color:var(--soft-border)]">
-          <PromptInputBody>
-            <PromptInputTextarea
-              value={text}
-              onChange={(event) => setText(event.target.value)}
-              placeholder="stripe.com — or ask how to rebuild a screen from the contract…"
-              disabled={busy}
-              className="min-h-12"
-            />
-          </PromptInputBody>
-          <PromptInputFooter>
-            <span className="px-1 font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
-              Design Contracts · Scan
-            </span>
-            <PromptInputSubmit
-              status={status}
-              disabled={!busy && !text.trim()}
-              onStop={() => stop()}
-            />
-          </PromptInputFooter>
-        </PromptInput>
+            {messages.map((message) => (
+              <Message
+                from={message.role}
+                key={message.id}
+                className={cn(
+                  'max-w-full animate-slide-in',
+                  message.role === 'user' ? 'max-w-[85%]' : 'max-w-full'
+                )}
+              >
+                <MessageContent
+                  className={cn(
+                    message.role === 'user' &&
+                      'rounded-2xl bg-secondary/80 px-4 py-2.5 text-[15px] leading-relaxed',
+                    message.role === 'assistant' &&
+                      'w-full max-w-none gap-3 text-[15px] leading-relaxed'
+                  )}
+                >
+                  {message.parts.map((part, index) => {
+                    if (part.type === 'text') {
+                      const content = partText(part)
+                      if (!content) return null
+                      return message.role === 'assistant' ? (
+                        <MessageResponse key={`${message.id}-t-${index}`}>
+                          {content}
+                        </MessageResponse>
+                      ) : (
+                        <p
+                          key={`${message.id}-t-${index}`}
+                          className="whitespace-pre-wrap"
+                        >
+                          {content}
+                        </p>
+                      )
+                    }
+                    if (isToolUIPart(part)) {
+                      return (
+                        <ToolPart key={`${message.id}-tool-${index}`} part={part} />
+                      )
+                    }
+                    return null
+                  })}
+                </MessageContent>
+              </Message>
+            ))}
+
+            {busy && messages.at(-1)?.role === 'user' ? (
+              <div className="flex items-center gap-2 px-1 text-sm text-muted-foreground animate-fade-in">
+                <span className="inline-flex gap-1">
+                  <span className="size-1.5 animate-pulse rounded-full bg-[oklch(0.78_0.08_185)]" />
+                  <span
+                    className="size-1.5 animate-pulse rounded-full bg-[oklch(0.78_0.08_185)]"
+                    style={{ animationDelay: '120ms' }}
+                  />
+                  <span
+                    className="size-1.5 animate-pulse rounded-full bg-[oklch(0.78_0.08_185)]"
+                    style={{ animationDelay: '240ms' }}
+                  />
+                </span>
+                Working…
+              </div>
+            ) : null}
+
+            {error ? (
+              <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+                {error.message || 'Something went wrong. Try again.'}
+              </div>
+            ) : null}
+          </ConversationContent>
+          <ConversationScrollButton />
+        </Conversation>
+
+        {/* Composer dock */}
+        <div className="relative shrink-0">
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-x-0 -top-10 h-10 bg-gradient-to-t from-background to-transparent"
+          />
+          <div className="mx-auto w-full max-w-2xl px-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] pt-1 sm:px-6">
+            <PromptInput
+              onSubmit={onSubmit}
+              className="border-[color:var(--soft-border)] bg-card/60 shadow-[0_-1px_0_0_oklch(1_0_0_/_0.03)] backdrop-blur-md"
+            >
+              <PromptInputBody>
+                <PromptInputTextarea
+                  value={text}
+                  onChange={(event) => setText(event.target.value)}
+                  placeholder="Ask about a site — stripe.com, linear.app…"
+                  disabled={busy && status === 'submitted'}
+                  className="min-h-[52px] text-[15px] leading-relaxed placeholder:text-muted-foreground/70"
+                  aria-label="Message"
+                />
+              </PromptInputBody>
+              <PromptInputFooter className="px-1">
+                <span className="truncate font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground/80">
+                  Design Contract
+                </span>
+                <PromptInputSubmit
+                  status={status}
+                  disabled={!busy && !text.trim()}
+                  onStop={() => stop()}
+                />
+              </PromptInputFooter>
+            </PromptInput>
+          </div>
+        </div>
       </div>
     </div>
   )

--- a/app/(marketing)/scan/page.tsx
+++ b/app/(marketing)/scan/page.tsx
@@ -1,48 +1,21 @@
-import type { Metadata } from 'next'
-import { Suspense } from 'react'
-import { MarketingFooter } from '@/components/organisms/marketing-footer'
-import { VercelHeader } from '@/components/organisms/vercel-header'
-import { ScanChat } from './client'
+import { redirect } from 'next/navigation'
 
-export const metadata: Metadata = {
-  title: 'Scan — Design Contracts',
-  description:
-    'Scan any public site into an installable Design Contract. Results appear inline; open the full page when you need every tab.',
-}
+type SearchParams = Promise<{ url?: string | string[] }>
 
-export default function ScanPage() {
-  return (
-    <div className="relative flex min-h-screen flex-col bg-background">
-      <div
-        aria-hidden
-        className="pointer-events-none absolute inset-0"
-        style={{
-          background:
-            'radial-gradient(800px 400px at 20% -10%, oklch(0.45 0.04 185 / 0.12), transparent 55%)',
-        }}
-      />
-      <div className="relative z-10 flex min-h-screen flex-col">
-        <VercelHeader currentPage="scan" />
-        <main className="mx-auto flex w-full max-w-3xl flex-1 flex-col px-4 py-10 sm:px-6">
-          <header className="mb-8">
-            <p className="font-mono text-[11px] uppercase tracking-[0.2em] text-muted-foreground">
-              Scan · Design Contracts
-            </p>
-            <h1 className="mt-3 font-serif text-4xl tracking-tight text-foreground sm:text-5xl">
-              designcontracts
-              <span className="font-mono text-[0.55em] text-[oklch(0.78_0.08_185)]">.sh</span>
-            </h1>
-            <p className="mt-3 max-w-2xl text-muted-foreground">
-              Paste a URL. Scan gathers tokens, layout DNA, and a contract pack — results land
-              inline with a path to the full library view.
-            </p>
-          </header>
-          <Suspense fallback={<div className="text-sm text-muted-foreground">Loading scan…</div>}>
-            <ScanChat />
-          </Suspense>
-        </main>
-        <MarketingFooter />
-      </div>
-    </div>
-  )
+/**
+ * Legacy /scan route — chat now lives on `/`.
+ * Preserve ?url= deep links.
+ */
+export default async function ScanPage({
+  searchParams,
+}: {
+  searchParams: SearchParams
+}) {
+  const params = await searchParams
+  const raw = Array.isArray(params.url) ? params.url[0] : params.url
+  const url = raw?.trim()
+  if (url) {
+    redirect(`/?url=${encodeURIComponent(url)}`)
+  }
+  redirect('/')
 }

--- a/app/(marketing)/site/[domain]/page.tsx
+++ b/app/(marketing)/site/[domain]/page.tsx
@@ -1,21 +1,19 @@
 "use client"
 
 import { useParams } from "next/navigation"
-import { useEffect, useState } from "react"
-import { VercelHeader } from "@/components/organisms/vercel-header"
+import { useEffect } from "react"
+import { AppChrome } from "@/components/organisms/app-chrome"
 import { ScanResultsLayout } from "@/components/organisms/scan-results-layout"
 import { useScanStore } from "@/stores/scan-store"
 
 export default function SitePage() {
   const params = useParams()
   const domain = params.domain as string
-  const [searchQuery, setSearchQuery] = useState(domain || "")
 
   const {
     isScanning: scanLoading,
     result: scanResult,
     error: scanError,
-    metrics: scanMetrics,
     progress: scanProgress,
     scanId,
     startScan,
@@ -23,13 +21,9 @@ export default function SitePage() {
   } = useScanStore()
 
   useEffect(() => {
-    setSearchQuery(domain || "")
-  }, [domain])
-
-  useEffect(() => {
     if (domain) {
       // Check if domain exists in database first, then scan if needed
-      checkExistingData(domain)
+      void checkExistingData(domain)
     }
   }, [domain])
 
@@ -113,21 +107,9 @@ export default function SitePage() {
   }
 
   return (
-    <div className="flex h-full w-full flex-col items-center justify-between overflow-hidden antialiased">
-      {/* Header */}
-      <VercelHeader
-        currentPage="site"
-        showSearch={true}
-        searchValue={searchQuery}
-        onSearchChange={setSearchQuery}
-        onScan={(newDomain) => {
-          // Allow scanning different domains from the site page
-          window.location.href = `/site/${encodeURIComponent(newDomain)}`
-        }}
-        isScanning={scanLoading}
-      />
+    <div className="flex h-dvh w-full flex-col overflow-hidden bg-background antialiased">
+      <AppChrome currentPage="site" />
 
-      {/* Scan Results */}
       <ScanResultsLayout
         result={scanResult}
         isLoading={scanLoading}

--- a/components/molecules/scan-result-widget.tsx
+++ b/components/molecules/scan-result-widget.tsx
@@ -1,8 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { ArrowUpRight, Download, Loader2 } from 'lucide-react'
-import { Button } from '@/components/ui/button'
+import { ArrowUpRight, Loader2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
 export type ScanWidgetPayload = {
@@ -54,11 +53,11 @@ type ScanResultWidgetProps = {
 
 function colorList(data: ScanWidgetPayload): string[] {
   const fromBrand = data.brand?.primaryColors?.filter(Boolean) ?? []
-  if (fromBrand.length > 0) return fromBrand.slice(0, 8)
+  if (fromBrand.length > 0) return fromBrand.slice(0, 6)
   return (data.tokens?.colors ?? [])
     .map((c) => c.value)
     .filter(Boolean)
-    .slice(0, 8)
+    .slice(0, 6)
 }
 
 function isPending(state?: string): boolean {
@@ -70,14 +69,14 @@ export function ScanResultWidget({ data, state, className }: ScanResultWidgetPro
     return (
       <div
         className={cn(
-          'border border-[color:var(--soft-border)] bg-background/70 px-4 py-4',
+          'flex items-center gap-2.5 rounded-xl border border-[color:var(--soft-border)] bg-secondary/30 px-3.5 py-3',
           className
         )}
       >
-        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <Loader2 className="h-4 w-4 animate-spin text-[oklch(0.78_0.08_185)]" />
+        <Loader2 className="size-3.5 shrink-0 animate-spin text-[oklch(0.78_0.08_185)]" />
+        <p className="text-sm text-muted-foreground">
           Scanning{data.domain ? ` ${data.domain}` : ''}…
-        </div>
+        </p>
       </div>
     )
   }
@@ -86,12 +85,12 @@ export function ScanResultWidget({ data, state, className }: ScanResultWidgetPro
     return (
       <div
         className={cn(
-          'border border-[color:var(--soft-border)] bg-background/70 px-4 py-4 text-sm text-muted-foreground',
+          'rounded-xl border border-[color:var(--soft-border)] bg-secondary/30 px-3.5 py-3 text-sm text-muted-foreground',
           className
         )}
       >
-        No cached contract for <span className="text-foreground">{data.domain}</span>. The agent will
-        scan next.
+        No cached contract for <span className="text-foreground">{data.domain}</span>. Scanning
+        next…
       </div>
     )
   }
@@ -102,92 +101,72 @@ export function ScanResultWidget({ data, state, className }: ScanResultWidgetPro
   const colors = colorList(data)
   const font =
     data.brand?.primaryFont || data.tokens?.typography?.families?.[0]?.value || null
-  const graph = data.graph?.summary || data.graphSummary || null
   const tokenCount =
     data.summary?.tokensExtracted ??
     (data.tokens?.colors?.length || 0) + (data.tokens?.typography?.families?.length || 0)
   const confidence = data.summary?.confidence
-  const downloadHref = data.designContract?.download || `/api/contracts/download?domain=${domain}`
+  const install = data.designContract?.installCommand
 
   return (
     <div
       className={cn(
-        'overflow-hidden border border-[color:var(--soft-border)] bg-background/80',
+        'overflow-hidden rounded-xl border border-[color:var(--soft-border)] bg-secondary/25',
         className
       )}
     >
-      {data.screenshots?.[0]?.url ? (
-        <div className="relative aspect-[16/7] w-full overflow-hidden border-b border-[color:var(--soft-border)] bg-muted/30">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src={data.screenshots[0].url}
-            alt={`${domain} capture`}
-            className="h-full w-full object-cover object-top"
-          />
-        </div>
-      ) : null}
-
-      <div className="space-y-4 px-4 py-4">
-        <div className="flex flex-wrap items-baseline justify-between gap-2">
-          <div>
-            <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
-              Design Contract
-              {data.status ? ` · ${data.status}` : ''}
-              {data.mode ? ` · ${data.mode}` : ''}
-            </p>
-            <h3 className="mt-1 font-serif text-2xl tracking-tight text-foreground">{domain}</h3>
-          </div>
-          {typeof confidence === 'number' ? (
-            <p className="font-mono text-xs text-muted-foreground">
-              {Math.round(confidence)}% confidence
-            </p>
-          ) : null}
-        </div>
-
-        {data.brand?.personality ? (
-          <p className="text-sm leading-relaxed text-muted-foreground">{data.brand.personality}</p>
-        ) : null}
-
-        {colors.length > 0 ? (
-          <div className="flex flex-wrap gap-1.5" aria-label="Primary colors">
-            {colors.map((value) => (
-              <span
-                key={value}
-                title={value}
-                className="h-7 w-7 border border-white/10"
-                style={{ backgroundColor: value }}
-              />
-            ))}
+      <div className="flex items-stretch gap-0">
+        {data.screenshots?.[0]?.url ? (
+          <div className="relative hidden w-28 shrink-0 overflow-hidden border-r border-[color:var(--soft-border)] sm:block">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={data.screenshots[0].url}
+              alt=""
+              className="absolute inset-0 h-full w-full object-cover object-top opacity-90"
+            />
           </div>
         ) : null}
 
-        <div className="flex flex-wrap gap-x-4 gap-y-1 font-mono text-[11px] text-muted-foreground">
-          {tokenCount ? <span>{tokenCount} tokens</span> : null}
-          {font ? <span>{font}</span> : null}
-          {graph?.roleCount != null ? <span>{graph.roleCount} roles</span> : null}
-          {graph?.componentCount != null ? <span>{graph.componentCount} components</span> : null}
-          {graph?.nodeCount != null ? <span>{graph.nodeCount} graph nodes</span> : null}
-        </div>
-
-        {data.designContract?.installCommand ? (
-          <code className="block overflow-x-auto border border-[color:var(--soft-border)] bg-muted/30 px-3 py-2 font-mono text-[11px] text-foreground">
-            {data.designContract.installCommand}
-          </code>
-        ) : null}
-
-        <div className="flex flex-wrap gap-2 pt-1">
-          <Button asChild size="sm" className="h-9 rounded-md gap-1.5">
-            <Link href={`/site/${domain}` as `/site/${string}`}>
-              View full results
-              <ArrowUpRight className="h-3.5 w-3.5" />
+        <div className="flex min-w-0 flex-1 flex-col gap-2.5 px-3.5 py-3">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+                Contract
+                {typeof confidence === 'number' ? ` · ${Math.round(confidence)}%` : ''}
+              </p>
+              <p className="mt-0.5 truncate font-medium tracking-tight text-foreground">
+                {domain}
+              </p>
+            </div>
+            <Link
+              href={`/site/${domain}` as `/site/${string}`}
+              className="inline-flex shrink-0 items-center gap-1 rounded-md px-2 py-1 text-xs text-muted-foreground transition hover:bg-secondary hover:text-foreground"
+            >
+              Open
+              <ArrowUpRight className="size-3.5" />
             </Link>
-          </Button>
-          <Button asChild size="sm" variant="outline" className="h-9 rounded-md gap-1.5">
-            <a href={downloadHref}>
-              <Download className="h-3.5 w-3.5" />
-              Download pack
-            </a>
-          </Button>
+          </div>
+
+          {colors.length > 0 ? (
+            <div className="flex items-center gap-1" aria-label="Primary colors">
+              {colors.map((value) => (
+                <span
+                  key={value}
+                  title={value}
+                  className="size-4 rounded-sm border border-white/10"
+                  style={{ backgroundColor: value }}
+                />
+              ))}
+              <span className="ml-2 truncate font-mono text-[11px] text-muted-foreground">
+                {[tokenCount ? `${tokenCount} tokens` : null, font].filter(Boolean).join(' · ')}
+              </span>
+            </div>
+          ) : null}
+
+          {install ? (
+            <code className="block truncate font-mono text-[11px] text-muted-foreground">
+              {install}
+            </code>
+          ) : null}
         </div>
       </div>
     </div>

--- a/components/organisms/app-chrome.tsx
+++ b/components/organisms/app-chrome.tsx
@@ -1,0 +1,100 @@
+'use client'
+
+import Link from 'next/link'
+import { useState } from 'react'
+import { Menu, X } from 'lucide-react'
+import { ThemeToggle } from '@/components/atoms/theme-toggle'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+const NAV = [
+  { href: '/community', label: 'Library' },
+  { href: '/docs', label: 'Docs' },
+] as const
+
+type AppChromeProps = {
+  currentPage?: 'home' | 'scan' | 'community' | 'docs' | 'site'
+  className?: string
+}
+
+/**
+ * Thin app chrome for the chat-first product surface.
+ * No marketing CTA, no footer — just brand + secondary nav.
+ */
+export function AppChrome({ currentPage = 'home', className }: AppChromeProps) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <header
+      className={cn(
+        'relative z-50 flex h-12 shrink-0 items-center border-b border-[color:var(--soft-border)] bg-background/85 px-3 backdrop-blur-xl sm:px-4',
+        className
+      )}
+      role="banner"
+    >
+      <Link
+        href="/"
+        className="flex items-baseline gap-0.5 outline-offset-4 transition-opacity hover:opacity-80"
+        aria-label="designcontracts.sh home"
+      >
+        <span className="font-serif text-base tracking-tight text-foreground sm:text-lg">
+          designcontracts
+        </span>
+        <span className="font-mono text-[10px] text-[oklch(0.78_0.08_185)]">.sh</span>
+      </Link>
+
+      <div className="ml-auto flex items-center gap-1">
+        <nav className="hidden items-center gap-0.5 sm:flex" aria-label="App navigation">
+          {NAV.map((item) => {
+            const active =
+              (item.href === '/community' && currentPage === 'community') ||
+              (item.href === '/docs' && currentPage === 'docs')
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={cn(
+                  'rounded-md px-2.5 py-1 text-sm transition-colors',
+                  active
+                    ? 'text-foreground'
+                    : 'text-muted-foreground hover:text-foreground'
+                )}
+              >
+                {item.label}
+              </Link>
+            )
+          })}
+        </nav>
+        <ThemeToggle />
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          className="sm:hidden"
+          onClick={() => setOpen((v) => !v)}
+          aria-label={open ? 'Close menu' : 'Open menu'}
+          aria-expanded={open}
+        >
+          {open ? <X className="h-4 w-4" /> : <Menu className="h-4 w-4" />}
+        </Button>
+      </div>
+
+      {open ? (
+        <nav
+          className="absolute inset-x-0 top-12 z-50 border-b border-[color:var(--soft-border)] bg-background/95 px-3 py-2 backdrop-blur-xl sm:hidden"
+          aria-label="Mobile navigation"
+        >
+          {NAV.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              onClick={() => setOpen(false)}
+              className="block rounded-md px-3 py-2.5 text-sm text-muted-foreground transition hover:bg-secondary hover:text-foreground"
+            >
+              {item.label}
+            </Link>
+          ))}
+        </nav>
+      ) : null}
+    </header>
+  )
+}

--- a/components/organisms/marketing-footer.tsx
+++ b/components/organisms/marketing-footer.tsx
@@ -5,7 +5,7 @@ const columns = [
   {
     title: "Product",
     links: [
-      { href: "/scan", label: "Scan" },
+      { href: "/", label: "Chat" },
       { href: "/community", label: "Library" },
       { href: "/pricing", label: "Pricing" },
       { href: "/features", label: "Features" },

--- a/components/organisms/marketing-header.tsx
+++ b/components/organisms/marketing-header.tsx
@@ -50,7 +50,7 @@ export function MarketingHeader({ currentPage = "home", showSearch = false }: Ma
 
     setScanLoading(true)
     try {
-      router.push(`/scan?url=${encodeURIComponent(target)}`)
+      router.push(`/?url=${encodeURIComponent(target)}`)
     } catch (error) {
       console.error('Scan error:', error)
     } finally {

--- a/components/organisms/vercel-header.tsx
+++ b/components/organisms/vercel-header.tsx
@@ -38,7 +38,7 @@ interface VercelHeaderProps {
 }
 
 const NAV = [
-  { href: "/scan", label: "Scan" },
+  { href: "/", label: "Chat" },
   { href: "/community", label: "Library" },
   { href: "/docs", label: "Docs" },
   { href: "/about", label: "About" },
@@ -76,7 +76,7 @@ export function VercelHeader({
       .split("/")[0]
     if (!domain) return
     if (onScan) onScan(domain)
-    else router.push(`/scan?url=${encodeURIComponent(domain)}`)
+    else router.push(`/?url=${encodeURIComponent(domain)}`)
     setMobileMenuOpen(false)
   }
 
@@ -133,9 +133,13 @@ export function VercelHeader({
           <nav className="hidden items-center gap-0.5 md:flex" aria-label="Main navigation">
             {NAV.map((item) => {
               const active =
-                currentPage === item.label.toLowerCase() ||
-                (item.href === "/scan" && (currentPage === "scan" || currentPage === "agent")) ||
-                (item.href === "/community" && currentPage === "community")
+                (item.href === "/" &&
+                  (currentPage === "home" ||
+                    currentPage === "scan" ||
+                    currentPage === "agent")) ||
+                (item.href === "/community" && currentPage === "community") ||
+                (item.href === "/docs" && currentPage === "docs") ||
+                (item.href === "/about" && currentPage === "about")
               return (
                 <Link
                   key={item.href}
@@ -152,13 +156,6 @@ export function VercelHeader({
               )
             })}
           </nav>
-
-          <Link
-            href="/scan"
-            className="hidden rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground transition hover:opacity-90 sm:inline-flex"
-          >
-            Start scan
-          </Link>
 
           <ThemeToggle />
 
@@ -190,13 +187,6 @@ export function VercelHeader({
                 {item.label}
               </Link>
             ))}
-            <Link
-              href="/scan"
-              onClick={() => setMobileMenuOpen(false)}
-              className="mt-2 rounded-md bg-primary px-3 py-2.5 text-center text-sm font-medium text-primary-foreground"
-            >
-              Start scan
-            </Link>
           </nav>
         </div>
       )}

--- a/lib/seo/internal-linking.ts
+++ b/lib/seo/internal-linking.ts
@@ -35,7 +35,7 @@ export const CORE_NAVIGATION_LINKS: InternalLink[] = [
     category: 'product'
   },
   {
-    href: '/scan',
+    href: '/',
     text: 'Scan Website',
     title: 'Extract design tokens from any website URL',
     priority: 'high',
@@ -195,7 +195,7 @@ export function generateContextualLinks(context: LinkingContext): InternalLink[]
           category: 'feature'
         },
         {
-          href: '/scan',
+          href: '/',
           text: 'Extract Your Own Tokens',
           title: 'Scan any website to extract design tokens',
           priority: 'high',
@@ -220,7 +220,7 @@ export function generateContextualLinks(context: LinkingContext): InternalLink[]
 
         // Link to scan functionality
         links.push({
-          href: `/scan?url=${siteData.domain}`,
+          href: `/?url=${siteData.domain}`,
           text: `Re-scan ${siteData.domain}`,
           title: `Extract latest design tokens from ${siteData.domain}`,
           priority: 'high',

--- a/lib/seo/structured-data.ts
+++ b/lib/seo/structured-data.ts
@@ -186,7 +186,7 @@ export function generateWebsiteSchema(): WebsiteSchema {
       "@type": "SearchAction",
       target: {
         "@type": "EntryPoint",
-        urlTemplate: "https://designcontracts.sh/scan?url={search_term_string}"
+        urlTemplate: "https://designcontracts.sh/?url={search_term_string}"
       },
       "query-input": "required name=search_term_string"
     },

--- a/next.config.ts
+++ b/next.config.ts
@@ -204,6 +204,9 @@ const nextConfig: NextConfig = {
       { source: '/home', destination: '/', permanent: true },
       { source: '/documentation', destination: '/docs', permanent: true },
       { source: '/api-docs', destination: '/docs', permanent: true },
+      // Chat is the product surface at /
+      { source: '/scan', destination: '/', permanent: false },
+      { source: '/agent', destination: '/', permanent: false },
     ]
   },
 

--- a/tests/e2e/scanner.spec.ts
+++ b/tests/e2e/scanner.spec.ts
@@ -12,16 +12,13 @@ test.describe('Scanner Basic Functionality', () => {
 		await expect(page).toHaveTitle(/Design Contracts/i);
 	});
 
-	test('should route homepage URL into scan', async ({ page }) => {
+	test('should show chat composer on homepage', async ({ page }) => {
 		await page.goto('/');
 
-		const urlInput = page.getByPlaceholder('stripe.com');
-		await expect(urlInput).toBeVisible();
-		await urlInput.fill('example.com');
-
-		await page.getByRole('button', { name: /scan site/i }).click();
-		await expect(page).toHaveURL(/\/scan\?url=example\.com/);
-		await expect(page.getByText(/Scan · Design Contracts/i)).toBeVisible();
+		const composer = page.getByLabel('Message');
+		await expect(composer).toBeVisible();
+		await expect(page.getByRole('heading', { name: /designcontracts/i })).toBeVisible();
+		await expect(page.getByRole('button', { name: 'stripe.com' })).toBeVisible();
 	});
 
 	test('should show error for invalid URL', async ({ page }) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Turns Design Contracts into an app-like chat product instead of a marketing site with a chat panel.

- **Home (`/`) is the chat** — full `dvh` shell, thin `AppChrome`, no footer
- **Professional chat UI** — centered empty state with brand + URL chips, docked composer, clean message bubbles, slim inline contract strips (no heavy cards)
- **`/scan` and `/agent` redirect to `/`** (preserves `?url=`)
- Library + site detail use the same app chrome (no marketing footer)

## Test plan
- [x] Local smoke: `/` 200, composer + empty state present, no footer
- [x] `/scan` → `/`, `/scan?url=example.com` → `/?url=example.com`
- [x] Unit tests (16) pass
- [ ] Visual check of empty state + streaming reply on production preview
- [ ] Confirm Library / Docs links from app chrome
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb424-02cd-75cc-ad48-89813fea64c0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb424-02cd-75cc-ad48-89813fea64c0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

