### PR TITLE
feat(ui): unify entire site under AppShell navigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,18 +17,22 @@
 | `/community` | Library | Directory of scanned contracts |
 | `/docs` | Docs | Install + API |
 | `/site/[domain]` | — | Detail view; **hydrate cache, don’t auto-rescan** |
+| `/features`, `/pricing`, `/about` | More | Same `AppShell`; quiet content via `PageCanvas` |
+| `/contact`, `/privacy`, `/terms` | Legal links | Same shell; no separate marketing chrome |
+| `/metrics` | — | Live metrics; still use `AppShell` |
 | `/scan`, `/agent` | → `/` | Redirects (keep `?url=`) |
 
 When adding pages:
-1. Decide if it’s a **product** route → wrap with `AppShell` + `currentPage`.
-2. Add a sidebar item in `AppShell` if users need persistent access.
+1. Wrap with `AppShell` + `currentPage` (and `PageCanvas` if scrollable).
+2. Add a sidebar item under Primary or More if users need persistent access.
 3. Update `DESIGN.md` route table and this file.
-4. Never introduce a second competing nav system on product routes.
+4. Never introduce a second competing nav (`MarketingHeader` / `MarketingFooter` / `VercelHeader`) on public routes.
 
 ## Design & UI rules (summary)
-- App-like: sidebar + canvas, **no marketing footer** on Chat / Library / Docs / Site.
+- App-like: sidebar + canvas, **no marketing footer** on any AppShell route.
 - Dark-first; mint accent (hue ~185); Geist + Instrument Serif; no purple-glow themes.
 - Chat empty state = brand + one line + chips + composer. No hero cards/stats.
+- Secondary pages: one title, one supporting line, list/sections — not card grids or blue gradient heroes.
 - Inline scan widgets stay compact; Open uses cached scan.
 - Details: [`DESIGN.md`](./DESIGN.md).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,10 +29,11 @@ When adding pages:
 4. Never introduce a second competing nav (`MarketingHeader` / `MarketingFooter` / `VercelHeader`) on public routes.
 
 ## Design & UI rules (summary)
-- **Warm Paper Workbench:** outer canvas `#f3eee5` + inset paper `#fffdf8` + terracotta `#9b4f32`.
+- **Warm Paper Workbench (dark-first):** canvas `#161310` + paper `#1f1b16` + terracotta accent; light cream optional.
+- Soft borders only (`--ui-border-soft` / `--ui-border`) — avoid hard outlines.
 - App shell: 240px sidebar on canvas → inset 12px-radius paper workspace (stats strip + body).
-- Controls: 28/32px with Shopify-style bevel shadows (`--shadow-control` / `--shadow-control-primary`).
-- Inter + JetBrains Mono. Soft warm borders; paper lift only on meaningful surfaces.
+- Controls: 28/32px with Shopify-style bevel shadows; theme toggle is a full-width segment in the sidebar.
+- Inter + JetBrains Mono. Paper lift only on meaningful surfaces.
 - Archetypes: chat = centered action (712px); library = dense operational list; docs = document (~760px).
 - No marketing footer / competing headers on AppShell routes. No nested card-shadow stacks.
 - Inline scan widgets stay compact; Open uses cache/handoff (no auto-rescan).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,11 +29,12 @@ When adding pages:
 4. Never introduce a second competing nav (`MarketingHeader` / `MarketingFooter` / `VercelHeader`) on public routes.
 
 ## Design & UI rules (summary)
-- App-like: sidebar + canvas, **no marketing footer** on any AppShell route.
-- **Cream-first** (`#f7f7f4`) + warm ink (`#26251e`) + scarce **Contract Orange** (`#f54e00`) — Cursor editorial system.
-- Inter (display/body weight 400) + JetBrains Mono (code). Hairline borders only — no shadows.
-- Chat empty state = brand + one line + chips + composer. No hero cards/stats.
-- Timeline pastels only for scan/agent stages — never CTAs.
+- **Warm Paper Workbench:** outer canvas `#f3eee5` + inset paper `#fffdf8` + terracotta `#9b4f32`.
+- App shell: 240px sidebar on canvas → inset 12px-radius paper workspace (stats strip + body).
+- Controls: 28/32px with Shopify-style bevel shadows (`--shadow-control` / `--shadow-control-primary`).
+- Inter + JetBrains Mono. Soft warm borders; paper lift only on meaningful surfaces.
+- Archetypes: chat = centered action (712px); library = dense operational list; docs = document (~760px).
+- No marketing footer / competing headers on AppShell routes. No nested card-shadow stacks.
 - Inline scan widgets stay compact; Open uses cache/handoff (no auto-rescan).
 - Details: [`DESIGN.md`](./DESIGN.md).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,8 @@ When adding pages:
 - `bun lint` runs the Next.js ESLint config; fix issues locally with `bun lint --fix` when supported.
 - No database migrate step for the default path — set `BLOB_READ_WRITE_TOKEN` + Upstash Redis env vars for durable storage.
 - Accurate scans need `SCANNER_SERVICE_URL` (e.g. `https://designcontracts-scanner.vercel.app`) + matching `SCANNER_SERVICE_SECRET`.
+- Blob persistence: `BLOB_READ_WRITE_TOKEN` required. Store may be public or private — `lib/storage/serverless-store.ts` tries both (override with `BLOB_ACCESS`).
+- `/site/[domain]` must hydrate from cache/handoff and **must not auto-rescan** on Open.
 - `bun run test` executes Playwright end-to-end suites; scope runs with `--project` or `--grep` when iterating.
 - `bun run test:unit` runs Vitest unit specs.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,10 +30,11 @@ When adding pages:
 
 ## Design & UI rules (summary)
 - App-like: sidebar + canvas, **no marketing footer** on any AppShell route.
-- Dark-first; mint accent (hue ~185); Geist + Instrument Serif; no purple-glow themes.
+- **Cream-first** (`#f7f7f4`) + warm ink (`#26251e`) + scarce **Contract Orange** (`#f54e00`) — Cursor editorial system.
+- Inter (display/body weight 400) + JetBrains Mono (code). Hairline borders only — no shadows.
 - Chat empty state = brand + one line + chips + composer. No hero cards/stats.
-- Secondary pages: one title, one supporting line, list/sections — not card grids or blue gradient heroes.
-- Inline scan widgets stay compact; Open uses cached scan.
+- Timeline pastels only for scan/agent stages — never CTAs.
+- Inline scan widgets stay compact; Open uses cache/handoff (no auto-rescan).
 - Details: [`DESIGN.md`](./DESIGN.md).
 
 ## Build, Test, and Development Commands

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,141 +1,127 @@
 # Design Contracts — DESIGN.md
 
 Canonical product design system for **designcontracts.sh**.  
-Adapted from the Cursor marketing design language (cream canvas, single-voltage orange, hairline depth).  
+**Warm Paper Workbench** — calm professional instrument: cream canvas, warm-white paper, terracotta accent, Shopify-style bevels.
+
 All UI work must follow this document. `DESIGN_SYSTEM.md` is legacy.
 
 ---
 
 ## Product surface
 
-Design Contracts is an **app**, not a brochure site — but it borrows Cursor’s editorial calm rather than a dark-IDE default.
+Design Contracts is an **app workbench**, not a brochure site.
 
 | Principle | Rule |
 |-----------|------|
-| Chat first | `/` is the chat workspace. Scanning happens in-chat. |
-| App chrome | Persistent left sidebar + main canvas. **No marketing footer** on product routes. |
-| Cream canvas | Warm cream (`#f7f7f4`), not pure white and not dark-IDE black. |
-| Single voltage | **Contract Orange** (`#f54e00`) for primary CTAs and the `.sh` wordmark — used scarcely. |
-| Hairline depth | No drop shadows. Cards float via 1px hairlines + white-on-cream contrast. |
-| Quiet type | Display weight stays **400** with negative tracking — magazine voice, never tech-bold. |
+| Chat first | `/` is the centered action canvas. Scanning happens in-chat. |
+| App chrome | Canvas + 240px sidebar + **inset paper workspace**. No marketing footer. |
+| Warm canvas | Outer `#f3eee5`; paper surfaces `#fffdf8`. Never pure white page bg. |
+| Single accent | Terracotta `#9b4f32` — scarce primary actions + `.sh` wordmark. |
+| Bevel depth | Controls use inset `--shadow-control`; paper uses `--shadow-paper`. |
+| Dense ops | Compress lists/queues; relax nav and empty states. |
 
 ### Product routes (use `AppShell`)
 
-| Route | Nav label | Purpose |
-|-------|-----------|---------|
-| `/` | Chat | Primary scan chat |
-| `/community` | Library | Scanned Design Contracts directory |
-| `/docs` | Docs | API + install guidance |
-| `/site/[domain]` | *(detail)* | Full contract — **hydrate from cache/handoff, never auto-rescan** |
-| `/features` `/pricing` `/about` | More | Quiet content via `PageCanvas` |
-| `/contact` `/privacy` `/terms` | Legal | Same shell |
+| Route | Nav | Archetype |
+|-------|-----|-----------|
+| `/` | Chat | Centered action canvas (712px) |
+| `/community` | Library | Full operational canvas (dense list) |
+| `/docs` | Docs | Document (~760px) |
+| `/site/[domain]` | detail | Document + optional modules |
+| `/features` `/pricing` `/about` | More | Document |
+| `/contact` `/privacy` `/terms` | Legal | Document / settings |
 
-### Legacy redirects
+---
 
-| From | To |
-|------|----|
-| `/scan`, `/agent` | `/` (preserve `?url=`) |
-| `/community/[domain]` | `/site/[domain]` |
+## Shell geometry
+
+```
+Outer warm canvas (#f3eee5)
+├── Global sidebar: 240px (on canvas, no card chrome)
+└── Inset workspace: 8px inset, 12px radius paper
+    ├── Utility strip: live Redis stats (36–44px)
+    ├── Optional location / view bars (integrated paper__toolbar)
+    └── Task body (chat / list / document)
+```
+
+Rules:
+- Toolbar + body + footer = **one paper sheet** (no floating toolbars).
+- Stronger borders only on shell edges (`--ui-border-edge`).
+- Soft borders for internal dividers (`--ui-border-soft`).
 
 ---
 
 ## Colors
 
-Mapped into CSS variables in `app/globals.css` (shadcn semantic names).
+Defined in `app/globals.css` as `--ui-*` and mapped to shadcn semantics.
 
-| Token | Hex | Role |
-|-------|-----|------|
-| `canvas` / `--background` | `#f7f7f4` | App canvas |
-| `canvas-soft` | `#fafaf7` | Soft inset panes |
-| `surface-card` / `--card` | `#ffffff` | Panels, composer, rows |
-| `ink` / `--foreground` | `#26251e` | Body + display ink (warm near-black) |
-| `body` / `--muted-foreground` | `#5a5852` | Secondary copy |
-| `muted` | `#807d72` | Captions |
-| `hairline` / `--border` | `#e6e5e0` | Default borders |
-| `hairline-soft` | `#efeee8` | Softer separators |
-| `primary` | `#f54e00` | Contract Orange — CTAs + `.sh` |
-| `primary-active` | `#d04200` | Pressed CTA |
-| `on-primary` | `#ffffff` | Text on orange |
-| `semantic-error` | `#cf2d56` | Errors |
-| `semantic-success` | `#1f8a65` | Success |
+| Token | Value | Role |
+|-------|-------|------|
+| `--ui-canvas` | `#f3eee5` | Outer app canvas |
+| `--ui-paper` | `#fffdf8` | Workspace / cards |
+| `--ui-paper-subtle` | `#faf5ec` | Toolbar tint, insets |
+| `--ui-paper-hover` | `#f5eee3` | Hover fill |
+| `--ui-paper-selected` | `#ede3d5` | Selected nav / segment |
+| `--ui-ink` | `#2b2723` | Primary text |
+| `--ui-ink-secondary` | `#675f57` | Body secondary |
+| `--ui-ink-muted` | `#766e65` | Meta / captions |
+| `--ui-accent` | `#9b4f32` | Primary CTA |
+| `--ui-accent-hover` | `#7a3f2a` | Pressed CTA |
+| `--ui-accent-soft` | `#f4e5db` | Soft accent wash |
+| `--ui-border-soft` | `rgba(67,52,38,0.10)` | Internal dividers |
+| `--ui-border` | `rgba(67,52,38,0.15)` | Default borders |
+| `--ui-border-edge` | `rgba(67,52,38,0.22)` | Shell edges |
 
-### Timeline pastels (scan/agent stages only)
+Dark mode is optional (warm dark paper). Light warm paper is the brand default.
 
-Scoped to in-product scan/agent stage indicators — **never** buttons, badges, or marketing accents.
+---
 
-| Stage | Hex |
+## Shadows
+
+| Token | Use |
 |-------|-----|
-| Thinking | `#dfa88f` |
-| Grepping / collect | `#9fc9a2` |
-| Reading | `#9fbbe0` |
-| Editing | `#c0a8dd` |
-| Done | `#c08532` |
+| `--shadow-control` | Buttons, inputs, segmented controls |
+| `--shadow-control-primary` | Primary buttons |
+| `--shadow-paper` | Persistent cards / inset workspace |
+| `--shadow-paper-hover` | Interactive cards (≤1px lift) |
+| `--shadow-float` | Menus, dialogs, drawers |
 
-Dark mode is optional (theme toggle). Cream light is the **default brand surface**.
+Do **not** stack paper shadows through nested cards. Rows and nav items: no external shadow.
 
 ---
 
 ## Typography
 
-| Role | Family | Notes |
-|------|--------|-------|
-| Display / UI | **Inter** (CursorGothic substitute) | Weight 400 on display; `-0.03em` tracking on large heroes |
-| Titles | Inter 600 | `title-md` 18px / `title-sm` 16px |
-| Body | Inter 400 | 14–16px, line-height 1.5 |
-| Code / meta | **JetBrains Mono** | Every code surface, install cmds, domain chips |
-
-Avoid bold display. Prefer weight 400–500 for chrome; 600 only for small titles.
-
----
-
-## Shape & spacing
-
-| Token | Value | Use |
-|-------|-------|-----|
-| `rounded.md` | 8px | Buttons, inputs (developer dialect) |
-| `rounded.lg` | 12px | Cards, panes, composer |
-| `rounded.pill` | 9999px | Chips, timeline pills |
-| Section rhythm | 80px | Marketing-style section padding when needed |
-| App padding | 16–24px | Product canvas |
-
-`--radius: 0.5rem` (8px) as base. **No box-shadow elevation.**
+| Role | Spec |
+|------|------|
+| UI / body | Inter (`--font-ui`), 13–15px |
+| Dense labels / meta | 12–13px, muted ink |
+| Section titles | 18–22px semibold |
+| Page titles | 22–28px semibold, restrained tracking |
+| Code / domains | JetBrains Mono |
+| Counts / dates | Tabular numerals |
 
 ---
 
-## App shell
+## Controls
 
-```
-┌─────────────────┐
-│ designcontracts.sh │  ← .sh in Contract Orange
-│                 │
-│ + New chat      │  ← orange primary (scarce)
-│ ○ Chat          │
-│ ○ Library       │
-│ ○ Docs          │
-│                 │
-│ Recents         │
-│ More / legal    │
-│ [theme]         │
-└─────────────────┘
-```
+| Size | Height | Use |
+|------|--------|-----|
+| Compact | 28px | Icon buttons, dense chrome |
+| Normal | 32px | Default buttons / inputs |
+| Emphasis | 36px | Rare high-emphasis only |
 
-- Sidebar: cream / white-on-cream, hairline `border-border`
-- Active nav: soft secondary fill (`#e6e5e0` / muted surface), not orange wash
-- Orange only on New chat CTA + wordmark `.sh`
+Beveled paper buttons via `Button` variants. At most one primary action per local region.
 
-### Chat empty state
+---
 
-1. Brand wordmark (`designcontracts` + orange `.sh`) — weight 400, tight tracking  
-2. One line: “Paste a URL. Get an installable Design Contract.”  
-3. Quiet domain chips (hairline pills)  
-4. Composer docked — white card on cream, 12px radius, hairline border  
+## Layout archetypes
 
-### Site / contract detail
+Use `PageCanvas` variants: `action` | `document` | `settings` | `operational`.
 
-- Domain as display title (weight 400)  
-- Hairline tabs + white panels  
-- Primary download button = Contract Orange  
-- Timeline pastels only if showing scan-phase UI  
+- **Chat**: centered 712px stack; composer pinned as integrated footer tint.
+- **Library**: full-width dense rows — `status | identity | title | flex | meta | actions`.
+- **Docs / More**: unboxed long-form; box only stateful modules (API endpoints, code).
 
 ---
 
@@ -143,30 +129,31 @@ Avoid bold display. Prefer weight 400–500 for chrome; 600 only for small title
 
 | Do | Don’t |
 |----|-------|
-| Use `AppShell` + `PageCanvas` | Marketing header/footer forks |
-| Semantic tokens (`bg-background`, `text-muted-foreground`) | Hard-code purple/indigo/mint themes |
-| Orange for one primary action | Orange washes, gradients, glow |
-| Hairline borders | Drop shadows / multi-layer elevation |
+| `AppShell` + inset paper | Marketing header/footer forks |
+| `--ui-*` / semantic tokens | Cool blue-gray outlines, pure-white canvas |
+| One terracotta primary | Accent washes, purple gradients, glow |
+| Integrated `paper__toolbar` | Floating rounded toolbars above content |
+| Bevel controls + paper lift | Shadow on every nested box |
 | Hydrate `/site` from cache/handoff | Auto-rescan on Open |
-| Timeline pastels for stages only | Pastels on CTAs or nav |
 
 ---
 
 ## Scanning UX
 
-1. Chat URL → `get_tokens` then `scan_site`  
-2. Inline widget → **Open** stashes handoff + hydrates Blob  
+1. Chat URL → tools → inline contract widget  
+2. **Open** stashes handoff + hydrates Blob  
 3. Never auto-rescan; empty state offers Scan now  
-4. Blob access auto-falls back public↔private (`BLOB_ACCESS` optional)  
+4. Redis stats strip ticks live (optimistic bumps + 4s poll)
 
 ---
 
 ## Checklist for new UI
 
-- [ ] Cream canvas + warm ink reads first  
-- [ ] At most one orange CTA in view  
-- [ ] Display weight 400; JetBrains Mono on code  
-- [ ] Hairlines only — no shadows  
-- [ ] Lives in `AppShell` if product route  
-- [ ] Mobile sidebar sheet still works  
-- [ ] Light default looks correct; dark toggle optional  
+- [ ] Outer canvas `#f3eee5`, paper `#fffdf8`
+- [ ] Inset workspace reads as one sheet
+- [ ] Controls 28/32px with bevel shadows
+- [ ] At most one terracotta CTA in view
+- [ ] Archetype chosen (action / document / operational)
+- [ ] No nested card-shadow stacks
+- [ ] Mobile drawer + touch targets OK
+- [ ] Light default correct; dark optional

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -24,6 +24,14 @@ Design Contracts is an **app**, not a marketing site.
 | `/community` | Library | Scanned Design Contracts directory |
 | `/docs` | Docs | API + install guidance |
 | `/site/[domain]` | *(detail)* | Full contract for one domain — **hydrate from cache, never auto-rescan** |
+| `/features` | Features (More) | Product capabilities |
+| `/pricing` | Pricing (More) | Plans |
+| `/about` | About (More) | Mission / principles |
+| `/contact` | Contact | Support channels |
+| `/privacy`, `/terms` | Legal | Policies |
+| `/metrics` | — | Internal live metrics (same shell) |
+
+Scrollable pages use `PageCanvas` inside `AppShell`. **No `MarketingHeader` / `MarketingFooter` on these routes.**
 
 ### Legacy redirects
 
@@ -31,8 +39,6 @@ Design Contracts is an **app**, not a marketing site.
 |------|----|
 | `/scan`, `/agent` | `/` (preserve `?url=`) |
 | `/community/[domain]` | `/site/[domain]` |
-
-Secondary pages (`/about`, `/pricing`, `/features`, legal) may use lighter chrome but should share tokens, type, and link back into the app shell (`/` / Library / Docs).
 
 ---
 
@@ -110,6 +116,11 @@ Lucide outline icons, 16–18px, consistent stroke. No emoji in chrome.
 │   stripe.com    │
 │   linear.app    │
 │                 │
+│ More            │
+│   Features      │
+│   Pricing       │
+│   About         │
+│   Contact · Privacy · Terms │
 │ [theme]         │
 └─────────────────┘
 ```
@@ -117,6 +128,7 @@ Lucide outline icons, 16–18px, consistent stroke. No emoji in chrome.
 - Width ~240px desktop; sheet/drawer on mobile
 - Recents from local history of opened/scanned domains → `/site/[domain]` or `/?url=`
 - Brand links to `/`
+- Secondary/legal pages stay in the same shell so nav never forks
 
 ### Main canvas
 
@@ -142,7 +154,7 @@ Not a full marketing card. Open → `/site/[domain]` **without rescanning**.
 
 | Do | Don’t |
 |----|-------|
-| Use `AppShell` on product routes | Add `MarketingFooter` on Chat/Library/Docs/Site |
+| Use `AppShell` + `PageCanvas` on all public app routes | Add `MarketingHeader` / `MarketingFooter` (legacy only) |
 | Use semantic tokens (`bg-background`, `text-muted-foreground`) | Hard-code purple/indigo gradients |
 | Prefer list rows / strips for results | Nest cards inside cards |
 | One primary CTA per section | Pill clusters / stat strips in first viewport |

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -48,9 +48,10 @@ Inspired by modern AI workspaces (sidebar + canvas, ⌘K density, soft panels) a
 
 ### Theme
 
-- **Default:** dark-first (`:root` = dark). Light mode is supported via `.light`.
-- **Accent:** cool mint (`oklch` hue ~185) — used sparingly for `.sh`, focus rings, active pills. **No purple glow.**
-- **Surfaces:** near-black canvas → slightly lifted sidebar → card panels. Depth from tone shifts + 1px borders, not multi-layer shadows.
+- **Default:** dark-first (`html.dark`). Light mode via `.light`.
+- **Palette:** shadcn/ui **neutral** tokens from [ui.shadcn.com theming](https://ui.shadcn.com/docs/theming) — achromatic surfaces, semantic `background` / `foreground` / `muted` / `border`.
+- **Brand accent:** mint only on the `.sh` wordmark (and rare scan cues). **No purple glow, no teal button themes.**
+- **Surfaces:** near-black canvas → slightly lifted sidebar/card. Depth from tone shifts + 1px borders, not multi-layer shadows.
 
 ### Tokens (CSS)
 
@@ -166,10 +167,16 @@ Not a full marketing card. Open → `/site/[domain]` **without rescanning**.
 
 1. User chats a URL → agent `get_tokens` then `scan_site` (accurate when scanner configured)
 2. Widget appears inline with mode/engine badge when available
-3. **Open** loads saved Blob/Redis scan — no second scan
-4. Explicit “New scan” only forces a fresh accurate run
+3. **Open** stashes a client handoff + hydrates `/api/sites/[domain]` — **never auto-rescans**
+4. Cache miss shows an empty state with explicit **Scan now** / **Open in Chat**
+5. Explicit “New scan” only forces a fresh accurate run
 
-Scanner wiring (ops): `SCANNER_SERVICE_URL` + `SCANNER_SERVICE_SECRET` on the Next.js project.
+### Persistence (ops)
+
+- Scans persist via Vercel Blob (`BLOB_READ_WRITE_TOKEN`). Code auto-falls back between `private` and `public` store access (Hobby stores are often public).
+- Upstash Redis optional for directory index speed; Blob alone is enough for `/site/[domain]` hydrate.
+- Optional: `BLOB_ACCESS=public|private` to skip probing.
+- Scanner wiring: `SCANNER_SERVICE_URL` + `SCANNER_SERVICE_SECRET` on the Next.js project.
 
 ---
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,20 +1,23 @@
 # Design Contracts — DESIGN.md
 
 Canonical product design system for **designcontracts.sh**.  
-All UI work must follow this document. Outdated notes in `DESIGN_SYSTEM.md` are superseded here.
+Adapted from the Cursor marketing design language (cream canvas, single-voltage orange, hairline depth).  
+All UI work must follow this document. `DESIGN_SYSTEM.md` is legacy.
 
 ---
 
 ## Product surface
 
-Design Contracts is an **app**, not a marketing site.
+Design Contracts is an **app**, not a brochure site — but it borrows Cursor’s editorial calm rather than a dark-IDE default.
 
 | Principle | Rule |
 |-----------|------|
 | Chat first | `/` is the chat workspace. Scanning happens in-chat. |
 | App chrome | Persistent left sidebar + main canvas. **No marketing footer** on product routes. |
-| One job | Each view has one purpose. Don’t stack hero + stats + promos on product pages. |
-| Quiet density | Linear / Raycast-like: hairline borders, soft surfaces, high contrast type — not purple glow or card soup. |
+| Cream canvas | Warm cream (`#f7f7f4`), not pure white and not dark-IDE black. |
+| Single voltage | **Contract Orange** (`#f54e00`) for primary CTAs and the `.sh` wordmark — used scarcely. |
+| Hairline depth | No drop shadows. Cards float via 1px hairlines + white-on-cream contrast. |
+| Quiet type | Display weight stays **400** with negative tracking — magazine voice, never tech-bold. |
 
 ### Product routes (use `AppShell`)
 
@@ -23,15 +26,9 @@ Design Contracts is an **app**, not a marketing site.
 | `/` | Chat | Primary scan chat |
 | `/community` | Library | Scanned Design Contracts directory |
 | `/docs` | Docs | API + install guidance |
-| `/site/[domain]` | *(detail)* | Full contract for one domain — **hydrate from cache, never auto-rescan** |
-| `/features` | Features (More) | Product capabilities |
-| `/pricing` | Pricing (More) | Plans |
-| `/about` | About (More) | Mission / principles |
-| `/contact` | Contact | Support channels |
-| `/privacy`, `/terms` | Legal | Policies |
-| `/metrics` | — | Internal live metrics (same shell) |
-
-Scrollable pages use `PageCanvas` inside `AppShell`. **No `MarketingHeader` / `MarketingFooter` on these routes.**
+| `/site/[domain]` | *(detail)* | Full contract — **hydrate from cache/handoff, never auto-rescan** |
+| `/features` `/pricing` `/about` | More | Quiet content via `PageCanvas` |
+| `/contact` `/privacy` `/terms` | Legal | Same shell |
 
 ### Legacy redirects
 
@@ -42,112 +39,103 @@ Scrollable pages use `PageCanvas` inside `AppShell`. **No `MarketingHeader` / `M
 
 ---
 
-## Visual language
+## Colors
 
-Inspired by modern AI workspaces (sidebar + canvas, ⌘K density, soft panels) adapted for Design Contracts.
+Mapped into CSS variables in `app/globals.css` (shadcn semantic names).
 
-### Theme
+| Token | Hex | Role |
+|-------|-----|------|
+| `canvas` / `--background` | `#f7f7f4` | App canvas |
+| `canvas-soft` | `#fafaf7` | Soft inset panes |
+| `surface-card` / `--card` | `#ffffff` | Panels, composer, rows |
+| `ink` / `--foreground` | `#26251e` | Body + display ink (warm near-black) |
+| `body` / `--muted-foreground` | `#5a5852` | Secondary copy |
+| `muted` | `#807d72` | Captions |
+| `hairline` / `--border` | `#e6e5e0` | Default borders |
+| `hairline-soft` | `#efeee8` | Softer separators |
+| `primary` | `#f54e00` | Contract Orange — CTAs + `.sh` |
+| `primary-active` | `#d04200` | Pressed CTA |
+| `on-primary` | `#ffffff` | Text on orange |
+| `semantic-error` | `#cf2d56` | Errors |
+| `semantic-success` | `#1f8a65` | Success |
 
-- **Default:** dark-first (`html.dark`). Light mode via `.light`.
-- **Palette:** shadcn/ui **neutral** tokens from [ui.shadcn.com theming](https://ui.shadcn.com/docs/theming) — achromatic surfaces, semantic `background` / `foreground` / `muted` / `border`.
-- **Brand accent:** mint only on the `.sh` wordmark (and rare scan cues). **No purple glow, no teal button themes.**
-- **Surfaces:** near-black canvas → slightly lifted sidebar/card. Depth from tone shifts + 1px borders, not multi-layer shadows.
+### Timeline pastels (scan/agent stages only)
 
-### Tokens (CSS)
+Scoped to in-product scan/agent stage indicators — **never** buttons, badges, or marketing accents.
 
-Defined in `app/globals.css`:
+| Stage | Hex |
+|-------|-----|
+| Thinking | `#dfa88f` |
+| Grepping / collect | `#9fc9a2` |
+| Reading | `#9fbbe0` |
+| Editing | `#c0a8dd` |
+| Done | `#c08532` |
 
-| Token | Role |
-|-------|------|
-| `--background` | App canvas |
-| `--sidebar` | Sidebar rail |
-| `--card` | Panels / composer / list rows |
-| `--foreground` / `--muted-foreground` | Primary / secondary type |
-| `--accent` | Mint accent surface |
-| `--soft-border` | Hairline separators |
-| `--radius` | Base radius (`0.75rem`); use `rounded-xl` / `rounded-2xl` for panels |
+Dark mode is optional (theme toggle). Cream light is the **default brand surface**.
 
-### Typography
+---
 
-| Role | Font | Notes |
-|------|------|-------|
-| Brand wordmark | Instrument Serif (`font-serif`) | `designcontracts` + mono `.sh` |
-| UI / body | Geist Sans | 14–15px body, clear hierarchy |
-| Meta / commands | Geist Mono | 10–12px uppercase tracking for labels; install cmds |
+## Typography
 
-Avoid Inter/Roboto/Arial as primary UI fonts.
+| Role | Family | Notes |
+|------|--------|-------|
+| Display / UI | **Inter** (CursorGothic substitute) | Weight 400 on display; `-0.03em` tracking on large heroes |
+| Titles | Inter 600 | `title-md` 18px / `title-sm` 16px |
+| Body | Inter 400 | 14–16px, line-height 1.5 |
+| Code / meta | **JetBrains Mono** | Every code surface, install cmds, domain chips |
 
-### Shape & spacing
+Avoid bold display. Prefer weight 400–500 for chrome; 600 only for small titles.
 
-- Panels / composer: `rounded-2xl`, thin border `border-[color:var(--soft-border)]`
-- Sidebar items: `rounded-lg`, active = `bg-sidebar-accent` or soft secondary fill
-- Padding: generous in main canvas; tighter in sidebar
-- **No cards in empty-state hero.** Cards only for interactive units (contract strip, library row)
+---
 
-### Motion
+## Shape & spacing
 
-Keep to 2–3 intentional motions:
+| Token | Value | Use |
+|-------|-------|-----|
+| `rounded.md` | 8px | Buttons, inputs (developer dialect) |
+| `rounded.lg` | 12px | Cards, panes, composer |
+| `rounded.pill` | 9999px | Chips, timeline pills |
+| Section rhythm | 80px | Marketing-style section padding when needed |
+| App padding | 16–24px | Product canvas |
 
-1. Empty-state fade/slide-in
-2. Message appear (`animate-slide-in`)
-3. Composer focus / submit feedback
-
-No decorative pulse/glow loops on idle chrome.
-
-### Icons
-
-Lucide outline icons, 16–18px, consistent stroke. No emoji in chrome.
+`--radius: 0.5rem` (8px) as base. **No box-shadow elevation.**
 
 ---
 
 ## App shell
 
-### Sidebar
-
 ```
 ┌─────────────────┐
-│ designcontracts.sh │
+│ designcontracts.sh │  ← .sh in Contract Orange
 │                 │
-│ + New chat      │
-│ ○ Chat          │  ← active on /
-│ ○ Library       │  ← /community
-│ ○ Docs          │  ← /docs
+│ + New chat      │  ← orange primary (scarce)
+│ ○ Chat          │
+│ ○ Library       │
+│ ○ Docs          │
 │                 │
 │ Recents         │
-│   stripe.com    │
-│   linear.app    │
-│                 │
-│ More            │
-│   Features      │
-│   Pricing       │
-│   About         │
-│   Contact · Privacy · Terms │
+│ More / legal    │
 │ [theme]         │
 └─────────────────┘
 ```
 
-- Width ~240px desktop; sheet/drawer on mobile
-- Recents from local history of opened/scanned domains → `/site/[domain]` or `/?url=`
-- Brand links to `/`
-- Secondary/legal pages stay in the same shell so nav never forks
-
-### Main canvas
-
-- Full remaining viewport height (`h-dvh`), `overflow-hidden` for chat
-- Chat: message column `max-w-2xl` centered; composer docked bottom with top fade
-- Library/Docs: scrollable main with page title + one supporting line
+- Sidebar: cream / white-on-cream, hairline `border-border`
+- Active nav: soft secondary fill (`#e6e5e0` / muted surface), not orange wash
+- Orange only on New chat CTA + wordmark `.sh`
 
 ### Chat empty state
 
-1. Brand wordmark (hero-level)
-2. One short line: “Paste a URL. Get an installable Design Contract.”
-3. Quiet domain chips (stripe.com, …)
-4. Composer docked below — not a marketing form
+1. Brand wordmark (`designcontracts` + orange `.sh`) — weight 400, tight tracking  
+2. One line: “Paste a URL. Get an installable Design Contract.”  
+3. Quiet domain chips (hairline pills)  
+4. Composer docked — white card on cream, 12px radius, hairline border  
 
-### Inline contract widget
+### Site / contract detail
 
-Compact horizontal strip (screenshot thumb optional + domain + swatches + Open).  
-Not a full marketing card. Open → `/site/[domain]` **without rescanning**.
+- Domain as display title (weight 400)  
+- Hairline tabs + white panels  
+- Primary download button = Contract Orange  
+- Timeline pastels only if showing scan-phase UI  
 
 ---
 
@@ -155,36 +143,30 @@ Not a full marketing card. Open → `/site/[domain]` **without rescanning**.
 
 | Do | Don’t |
 |----|-------|
-| Use `AppShell` + `PageCanvas` on all public app routes | Add `MarketingHeader` / `MarketingFooter` (legacy only) |
-| Use semantic tokens (`bg-background`, `text-muted-foreground`) | Hard-code purple/indigo gradients |
-| Prefer list rows / strips for results | Nest cards inside cards |
-| One primary CTA per section | Pill clusters / stat strips in first viewport |
-| Hydrate site pages from `/api/sites/[domain]` | Call `startScan` when cache exists |
+| Use `AppShell` + `PageCanvas` | Marketing header/footer forks |
+| Semantic tokens (`bg-background`, `text-muted-foreground`) | Hard-code purple/indigo/mint themes |
+| Orange for one primary action | Orange washes, gradients, glow |
+| Hairline borders | Drop shadows / multi-layer elevation |
+| Hydrate `/site` from cache/handoff | Auto-rescan on Open |
+| Timeline pastels for stages only | Pastels on CTAs or nav |
 
 ---
 
-## Scanning UX (product)
+## Scanning UX
 
-1. User chats a URL → agent `get_tokens` then `scan_site` (accurate when scanner configured)
-2. Widget appears inline with mode/engine badge when available
-3. **Open** stashes a client handoff + hydrates `/api/sites/[domain]` — **never auto-rescans**
-4. Cache miss shows an empty state with explicit **Scan now** / **Open in Chat**
-5. Explicit “New scan” only forces a fresh accurate run
-
-### Persistence (ops)
-
-- Scans persist via Vercel Blob (`BLOB_READ_WRITE_TOKEN`). Code auto-falls back between `private` and `public` store access (Hobby stores are often public).
-- Upstash Redis optional for directory index speed; Blob alone is enough for `/site/[domain]` hydrate.
-- Optional: `BLOB_ACCESS=public|private` to skip probing.
-- Scanner wiring: `SCANNER_SERVICE_URL` + `SCANNER_SERVICE_SECRET` on the Next.js project.
+1. Chat URL → `get_tokens` then `scan_site`  
+2. Inline widget → **Open** stashes handoff + hydrates Blob  
+3. Never auto-rescan; empty state offers Scan now  
+4. Blob access auto-falls back public↔private (`BLOB_ACCESS` optional)  
 
 ---
 
 ## Checklist for new UI
 
-- [ ] Lives inside `AppShell` if it’s a product route
-- [ ] No footer; sidebar nav still works
-- [ ] Uses DESIGN.md tokens/type/radius
-- [ ] Active nav item matches route
-- [ ] Mobile: sidebar collapses to sheet; chat remains usable
-- [ ] Dark default looks correct; light mode not broken
+- [ ] Cream canvas + warm ink reads first  
+- [ ] At most one orange CTA in view  
+- [ ] Display weight 400; JetBrains Mono on code  
+- [ ] Hairlines only — no shadows  
+- [ ] Lives in `AppShell` if product route  
+- [ ] Mobile sidebar sheet still works  
+- [ ] Light default looks correct; dark toggle optional  

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -36,8 +36,9 @@ Design Contracts is an **app workbench**, not a brochure site.
 ## Shell geometry
 
 ```
-Outer warm canvas (#f3eee5)
+Outer warm canvas (dark `#161310` / light `#f3eee5`)
 ├── Global sidebar: 240px (on canvas, no card chrome)
+│   └── Theme segment (Dark / Light / Auto)
 └── Inset workspace: 8px inset, 12px radius paper
     ├── Utility strip: live Redis stats (36–44px)
     ├── Optional location / view bars (integrated paper__toolbar)
@@ -46,8 +47,8 @@ Outer warm canvas (#f3eee5)
 
 Rules:
 - Toolbar + body + footer = **one paper sheet** (no floating toolbars).
-- Stronger borders only on shell edges (`--ui-border-edge`).
-- Soft borders for internal dividers (`--ui-border-soft`).
+- Prefer `--ui-border-soft` everywhere; `--ui-border` only for shell edges.
+- Theme defaults to **dark**; FOUC script + `html.dark` enforce it.
 
 ---
 

--- a/app/(marketing)/about/page.tsx
+++ b/app/(marketing)/about/page.tsx
@@ -31,35 +31,39 @@ const principles = [
 export default function AboutPage() {
   return (
     <AppShell currentPage="about">
-      <PageCanvas>
-        <h1 className="font-normal tracking-tight text-3xl tracking-tight text-foreground sm:text-4xl">About</h1>
-        <p className="mt-2 text-[15px] leading-relaxed text-muted-foreground">
+      <PageCanvas variant="document">
+        <h1 className="text-[22px] font-semibold tracking-tight text-[var(--ui-ink)] sm:text-[26px]">
+          About
+        </h1>
+        <p className="mt-2 max-w-xl text-[15px] leading-relaxed text-[var(--ui-ink-secondary)]">
           designcontracts.sh makes every public design system discoverable and installable for AI
           agents — starting from a URL in chat.
         </p>
 
-        <section className="mt-12 space-y-8">
+        <section className="mt-10 space-y-6">
           {principles.map((item) => (
             <div
               key={item.title}
-              className="border-t border-[color:var(--soft-border)] pt-6 first:border-t-0 first:pt-0"
+              className="border-t border-[var(--ui-border-soft)] pt-5 first:border-t-0 first:pt-0"
             >
-              <h2 className="text-[15px] font-medium text-foreground">{item.title}</h2>
-              <p className="mt-2 text-sm leading-relaxed text-muted-foreground">{item.body}</p>
+              <h2 className="text-[14px] font-semibold text-[var(--ui-ink)]">{item.title}</h2>
+              <p className="mt-1.5 text-[13px] leading-relaxed text-[var(--ui-ink-secondary)]">
+                {item.body}
+              </p>
             </div>
           ))}
         </section>
 
-        <div className="mt-14 flex flex-wrap gap-3">
+        <div className="mt-12 flex flex-wrap gap-2">
           <Link
             href="/"
-            className="inline-flex h-10 items-center rounded-xl bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90"
+            className="inline-flex h-8 items-center rounded-[7px] bg-[var(--ui-accent)] px-2.5 text-[13px] font-medium text-[var(--ui-paper)] shadow-[var(--shadow-control-primary)] transition hover:bg-[var(--ui-accent-hover)]"
           >
             Open Chat
           </Link>
           <Link
             href="/contact"
-            className="inline-flex h-10 items-center rounded-xl border border-[color:var(--soft-border)] px-4 text-sm font-medium text-foreground transition hover:bg-muted/40"
+            className="inline-flex h-8 items-center rounded-[7px] bg-[var(--ui-paper)] px-2.5 text-[13px] font-medium text-[var(--ui-ink)] shadow-[var(--shadow-control)] transition hover:bg-[var(--ui-paper-hover)]"
           >
             Contact
           </Link>

--- a/app/(marketing)/about/page.tsx
+++ b/app/(marketing)/about/page.tsx
@@ -1,338 +1,70 @@
-import { Metadata } from "next"
-import {
-  Heart,
-  Target,
-  Users,
-  Lightbulb,
-  Globe,
-  Code,
-  Palette,
-  Zap,
-  Shield,
-  Rocket
-} from "lucide-react"
-import { MarketingHeader } from "@/components/organisms/marketing-header"
-import { MarketingFooter } from "@/components/organisms/marketing-footer"
-import { Card, CardContent } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { AppShell } from '@/components/organisms/app-shell'
+import { PageCanvas } from '@/components/molecules/page-canvas'
 
 export const metadata: Metadata = {
-  title: "About - designcontracts.sh",
-  description: "Learn about our mission to make design tokens accessible to everyone through AI-powered extraction and analysis.",
-  openGraph: {
-    title: "About - designcontracts.sh",
-    description: "Making design tokens accessible through AI",
-  },
+  title: 'About — designcontracts.sh',
+  description:
+    'Design Contracts turns public sites into installable, AI-readable design systems.',
 }
 
-const values = [
+const principles = [
   {
-    icon: Lightbulb,
-    title: "Innovation First",
-    description: "We push the boundaries of what's possible with AI and design system analysis."
+    title: 'Contracts, not dumps',
+    body: 'Agents need relationships — tokens tied to roles, components, and layout DNA — not a flat CSS inventory.',
   },
   {
-    icon: Globe,
-    title: "Open by Default",
-    description: "We believe in transparency, open standards, and community-driven development."
+    title: 'Chat-first workspace',
+    body: 'Scanning lives inside conversation. Open a contract from an inline widget; never force a marketing tour.',
   },
   {
-    icon: Users,
-    title: "Developer Experience",
-    description: "Every decision is made with developers and designers in mind."
+    title: 'Public web, privacy-aware',
+    body: 'We scan public CSS with robots respect and clear opt-out. Store only what agents need to rebuild UI.',
   },
   {
-    icon: Shield,
-    title: "Privacy Focused",
-    description: "We respect privacy, follow web standards, and provide clear opt-out mechanisms."
-  }
-]
-
-const timeline = [
-  {
-    year: "2024",
-    quarter: "Q1",
-    title: "The Vision",
-    description: "Recognized the need for automated design token extraction while working with multiple design systems."
+    title: 'Open standards',
+    body: 'W3C design tokens, MCP tools, and installable packs that fit Claude Code and other agent workflows.',
   },
-  {
-    year: "2024",
-    quarter: "Q2",
-    title: "First Prototype",
-    description: "Built initial CSS analysis engine with basic token detection capabilities."
-  },
-  {
-    year: "2024",
-    quarter: "Q3",
-    title: "AI Integration",
-    description: "Integrated AI-powered pattern recognition and layout DNA analysis."
-  },
-  {
-    year: "2024",
-    quarter: "Q4",
-    title: "Public Beta",
-    description: "Launched public beta with community directory and MCP integration."
-  }
-]
-
-const stats = [
-  {
-    number: "10,000+",
-    label: "Websites Analyzed"
-  },
-  {
-    number: "500K+",
-    label: "Design Tokens Extracted"
-  },
-  {
-    number: "95%+",
-    label: "Accuracy Rate"
-  },
-  {
-    number: "< 30s",
-    label: "Average Analysis Time"
-  }
-]
+] as const
 
 export default function AboutPage() {
   return (
-    <>
-      <MarketingHeader currentPage="about" showSearch={true} />
+    <AppShell currentPage="about">
+      <PageCanvas>
+        <h1 className="font-serif text-3xl tracking-tight text-foreground sm:text-4xl">About</h1>
+        <p className="mt-2 text-[15px] leading-relaxed text-muted-foreground">
+          designcontracts.sh makes every public design system discoverable and installable for AI
+          agents — starting from a URL in chat.
+        </p>
 
-      <main className="min-h-screen bg-background">
-        {/* Hero Section */}
-        <section className="py-20 px-4">
-          <div className="max-w-4xl mx-auto text-center">
-            <Badge variant="outline" className="mb-6">
-              Our Story
-            </Badge>
-            <h1 className="text-4xl md:text-6xl font-bold tracking-tight mb-6">
-              Making design tokens{" "}
-              <span className="text-blue-600 dark:text-blue-400">accessible</span>{" "}
-              to everyone
-            </h1>
-            <p className="text-xl text-muted-foreground mb-8 max-w-2xl mx-auto">
-              We believe that every design system should be discoverable, analyzable, and
-              actionable. Our mission is to democratize access to design tokens through
-              AI-powered extraction and analysis.
-            </p>
-          </div>
+        <section className="mt-12 space-y-8">
+          {principles.map((item) => (
+            <div
+              key={item.title}
+              className="border-t border-[color:var(--soft-border)] pt-6 first:border-t-0 first:pt-0"
+            >
+              <h2 className="text-[15px] font-medium text-foreground">{item.title}</h2>
+              <p className="mt-2 text-sm leading-relaxed text-muted-foreground">{item.body}</p>
+            </div>
+          ))}
         </section>
 
-        {/* Mission Section */}
-        <section className="py-16 px-4">
-          <div className="max-w-6xl mx-auto">
-            <div className="grid lg:grid-cols-2 gap-12 items-center">
-              <div>
-                <h2 className="text-3xl font-bold mb-6">Our Mission</h2>
-                <div className="space-y-6">
-                  <div className="flex items-start gap-4">
-                    <Target className="h-6 w-6 text-blue-600 dark:text-blue-400 mt-1 flex-shrink-0" />
-                    <div>
-                      <h3 className="font-semibold mb-2">Accelerate Design Systems</h3>
-                      <p className="text-muted-foreground">
-                        Reduce the time it takes to analyze and extract design tokens from weeks to seconds.
-                      </p>
-                    </div>
-                  </div>
-
-                  <div className="flex items-start gap-4">
-                    <Heart className="h-6 w-6 text-blue-600 dark:text-blue-400 mt-1 flex-shrink-0" />
-                    <div>
-                      <h3 className="font-semibold mb-2">Empower Creativity</h3>
-                      <p className="text-muted-foreground">
-                        Help designers and developers learn from the best design systems on the web.
-                      </p>
-                    </div>
-                  </div>
-
-                  <div className="flex items-start gap-4">
-                    <Code className="h-6 w-6 text-blue-600 dark:text-blue-400 mt-1 flex-shrink-0" />
-                    <div>
-                      <h3 className="font-semibold mb-2">Enable AI Workflows</h3>
-                      <p className="text-muted-foreground">
-                        Provide AI agents with structured, actionable design token data for intelligent design decisions.
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              <div className="grid grid-cols-2 gap-6">
-                {stats.map((stat, index) => (
-                  <Card key={index} className="border-muted text-center">
-                    <CardContent className="p-6">
-                      <div className="text-2xl font-bold text-blue-600 dark:text-blue-400 mb-2">
-                        {stat.number}
-                      </div>
-                      <div className="text-sm text-muted-foreground">{stat.label}</div>
-                    </CardContent>
-                  </Card>
-                ))}
-              </div>
-            </div>
-          </div>
-        </section>
-
-        {/* Values Section */}
-        <section className="py-16 px-4 bg-muted/30">
-          <div className="max-w-6xl mx-auto">
-            <div className="text-center mb-12">
-              <h2 className="text-3xl font-bold mb-4">Our Values</h2>
-              <p className="text-muted-foreground">
-                The principles that guide every decision we make
-              </p>
-            </div>
-
-            <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
-              {values.map((value) => (
-                <Card key={value.title} className="border-muted text-center">
-                  <CardContent className="p-6">
-                    <value.icon className="h-8 w-8 text-blue-600 dark:text-blue-400 mx-auto mb-4" />
-                    <h3 className="font-semibold mb-2">{value.title}</h3>
-                    <p className="text-muted-foreground text-sm">{value.description}</p>
-                  </CardContent>
-                </Card>
-              ))}
-            </div>
-          </div>
-        </section>
-
-        {/* Timeline Section */}
-        <section className="py-16 px-4">
-          <div className="max-w-4xl mx-auto">
-            <div className="text-center mb-12">
-              <h2 className="text-3xl font-bold mb-4">Our Journey</h2>
-              <p className="text-muted-foreground">
-                From idea to the platform that's changing how we work with design tokens
-              </p>
-            </div>
-
-            <div className="space-y-8">
-              {timeline.map((item, index) => (
-                <div key={index} className="flex items-start gap-6">
-                  <div className="flex-shrink-0">
-                    <div className="w-16 h-16 rounded-full bg-blue-600 dark:bg-blue-400 text-white dark:text-black flex items-center justify-center font-bold">
-                      {item.quarter}
-                    </div>
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-3 mb-2">
-                      <h3 className="font-semibold">{item.title}</h3>
-                      <Badge variant="outline">{item.year}</Badge>
-                    </div>
-                    <p className="text-muted-foreground">{item.description}</p>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        </section>
-
-        {/* Technology Section */}
-        <section className="py-16 px-4 bg-muted/30">
-          <div className="max-w-6xl mx-auto">
-            <div className="text-center mb-12">
-              <h2 className="text-3xl font-bold mb-4">Built with Modern Technology</h2>
-              <p className="text-muted-foreground">
-                Leveraging the latest in AI, web technologies, and design system standards
-              </p>
-            </div>
-
-            <div className="grid md:grid-cols-3 gap-6">
-              <Card className="border-muted">
-                <CardContent className="p-6 text-center">
-                  <Palette className="h-8 w-8 text-blue-600 dark:text-blue-400 mx-auto mb-4" />
-                  <h3 className="font-semibold mb-2">CSS Analysis Engine</h3>
-                  <p className="text-muted-foreground text-sm">
-                    Advanced CSS parsing and analysis using Project Wallace's MIT-licensed extractors.
-                  </p>
-                </CardContent>
-              </Card>
-
-              <Card className="border-muted">
-                <CardContent className="p-6 text-center">
-                  <Zap className="h-8 w-8 text-blue-600 dark:text-blue-400 mx-auto mb-4" />
-                  <h3 className="font-semibold mb-2">AI Pattern Recognition</h3>
-                  <p className="text-muted-foreground text-sm">
-                    Machine learning models trained on thousands of design systems for intelligent token detection.
-                  </p>
-                </CardContent>
-              </Card>
-
-              <Card className="border-muted">
-                <CardContent className="p-6 text-center">
-                  <Rocket className="h-8 w-8 text-blue-600 dark:text-blue-400 mx-auto mb-4" />
-                  <h3 className="font-semibold mb-2">Modern Infrastructure</h3>
-                  <p className="text-muted-foreground text-sm">
-                    Built on Next.js 16, Supabase, and optimized for performance and scalability.
-                  </p>
-                </CardContent>
-              </Card>
-            </div>
-          </div>
-        </section>
-
-        {/* Open Source Section */}
-        <section className="py-16 px-4">
-          <div className="max-w-4xl mx-auto text-center">
-            <h2 className="text-3xl font-bold mb-4">Open Source Commitment</h2>
-            <p className="text-muted-foreground mb-8 max-w-2xl mx-auto">
-              We believe in giving back to the community. Our extraction tools are built on
-              MIT-licensed open source projects, and we contribute back to the ecosystem.
-            </p>
-
-            <div className="grid md:grid-cols-2 gap-6">
-              <Card className="border-muted">
-                <CardContent className="p-6">
-                  <h3 className="font-semibold mb-2">Based on Project Wallace</h3>
-                  <p className="text-muted-foreground text-sm">
-                    Our CSS extraction engine is built on Project Wallace's excellent MIT-licensed tools,
-                    ensuring compatibility and reliability.
-                  </p>
-                </CardContent>
-              </Card>
-
-              <Card className="border-muted">
-                <CardContent className="p-6">
-                  <h3 className="font-semibold mb-2">W3C Standards</h3>
-                  <p className="text-muted-foreground text-sm">
-                    All our token outputs follow W3C design token standards, ensuring
-                    compatibility with design tools and workflows.
-                  </p>
-                </CardContent>
-              </Card>
-            </div>
-          </div>
-        </section>
-
-        {/* Contact CTA */}
-        <section className="py-20 px-4 text-center">
-          <div className="max-w-2xl mx-auto">
-            <h2 className="text-3xl font-bold mb-4">Let's build the future together</h2>
-            <p className="text-muted-foreground mb-8">
-              Have questions about our mission, technology, or want to contribute to our vision?
-              We'd love to hear from you.
-            </p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <a
-                href="/contact"
-                className="px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-md font-medium transition-colors"
-              >
-                Get in touch
-              </a>
-              <a
-                href="/community"
-                className="px-6 py-3 border border-muted-foreground/20 hover:bg-muted rounded-md font-medium transition-colors"
-              >
-                Join community
-              </a>
-            </div>
-          </div>
-        </section>
-      </main>
-
-      <MarketingFooter />
-    </>
+        <div className="mt-14 flex flex-wrap gap-3">
+          <Link
+            href="/"
+            className="inline-flex h-10 items-center rounded-xl bg-foreground px-4 text-sm font-medium text-background transition hover:opacity-90"
+          >
+            Open Chat
+          </Link>
+          <Link
+            href="/contact"
+            className="inline-flex h-10 items-center rounded-xl border border-[color:var(--soft-border)] px-4 text-sm font-medium text-foreground transition hover:bg-muted/40"
+          >
+            Contact
+          </Link>
+        </div>
+      </PageCanvas>
+    </AppShell>
   )
 }

--- a/app/(marketing)/about/page.tsx
+++ b/app/(marketing)/about/page.tsx
@@ -32,7 +32,7 @@ export default function AboutPage() {
   return (
     <AppShell currentPage="about">
       <PageCanvas>
-        <h1 className="font-serif text-3xl tracking-tight text-foreground sm:text-4xl">About</h1>
+        <h1 className="font-normal tracking-tight text-3xl tracking-tight text-foreground sm:text-4xl">About</h1>
         <p className="mt-2 text-[15px] leading-relaxed text-muted-foreground">
           designcontracts.sh makes every public design system discoverable and installable for AI
           agents — starting from a URL in chat.
@@ -53,7 +53,7 @@ export default function AboutPage() {
         <div className="mt-14 flex flex-wrap gap-3">
           <Link
             href="/"
-            className="inline-flex h-10 items-center rounded-xl bg-foreground px-4 text-sm font-medium text-background transition hover:opacity-90"
+            className="inline-flex h-10 items-center rounded-xl bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90"
           >
             Open Chat
           </Link>

--- a/app/(marketing)/community/client.tsx
+++ b/app/(marketing)/community/client.tsx
@@ -6,6 +6,7 @@ import { ArrowUp, Clock, ExternalLink, Search, Sparkles } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { AppShell } from '@/components/organisms/app-shell'
+import { trackClientEvent } from '@/lib/analytics/track-client'
 import { useVotingStore } from '@/stores/voting-store'
 import { cn } from '@/lib/utils'
 
@@ -47,6 +48,10 @@ export default function CommunityClient() {
   useEffect(() => {
     loadVotes()
   }, [loadVotes])
+
+  useEffect(() => {
+    trackClientEvent('library_view')
+  }, [])
 
   useEffect(() => {
     let cancelled = false

--- a/app/(marketing)/community/client.tsx
+++ b/app/(marketing)/community/client.tsx
@@ -123,187 +123,186 @@ export default function CommunityClient() {
 
   return (
     <AppShell currentPage="library">
-      <div className="min-h-0 flex-1 overflow-y-auto" role="region" aria-label="Design Contracts library">
-          <section className="border-b border-[color:var(--soft-border)] px-4 pb-6 pt-8 sm:px-6">
-            <div className="mx-auto max-w-3xl">
-              <h1 className="font-normal tracking-tight text-3xl tracking-tight text-foreground">Library</h1>
-              <p className="mt-2 max-w-xl text-sm text-muted-foreground">
-                Design Contracts from public sites. Open one, or ask Chat to gather a new system.
-              </p>
+      <div
+        className="flex min-h-0 flex-1 flex-col overflow-hidden"
+        role="region"
+        aria-label="Design Contracts library"
+      >
+        {/* Location bar */}
+        <div className="paper__toolbar !min-h-11 shrink-0 justify-between !px-3 sm:!px-4">
+          <div className="min-w-0">
+            <h1 className="text-[15px] font-semibold tracking-tight text-[var(--ui-ink)]">
+              Library
+            </h1>
+            <p className="truncate text-[12px] text-[var(--ui-ink-muted)]">
+              Design Contracts from public sites
+            </p>
+          </div>
+          <Button asChild size="sm">
+            <Link href="/">New scan</Link>
+          </Button>
+        </div>
 
-              <div className="relative mt-6 max-w-xl">
-                <Search
-                  className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
-                  aria-hidden
-                />
-                <Input
-                  id="community-search"
-                  type="search"
-                  placeholder="Search domains…"
-                  value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                  className="h-11 rounded-xl border-[color:var(--soft-border)] bg-card/60 pl-10"
-                  aria-label="Search scanned sites"
-                />
-              </div>
-            </div>
-          </section>
-
-          <section className="sticky top-0 z-20 border-b border-[color:var(--soft-border)] bg-background/90 backdrop-blur-xl">
-            <div className="mx-auto flex max-w-3xl items-center justify-between gap-4 px-4 py-3 sm:px-6">
-              <p className="font-mono text-[11px] text-muted-foreground">
-                {filteredSites.length} {filteredSites.length === 1 ? 'site' : 'sites'}
-              </p>
-              <div
-                className="flex gap-1 border border-[color:var(--soft-border)] p-1"
-                role="tablist"
-                aria-label="Sort options"
+        {/* View bar — search + sort */}
+        <div className="paper__toolbar !min-h-11 shrink-0 flex-wrap !gap-2 !px-3 sm:!px-4">
+          <div className="relative min-w-[200px] max-w-sm flex-1">
+            <Search
+              className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-[var(--ui-ink-muted)]"
+              aria-hidden
+            />
+            <Input
+              id="community-search"
+              type="search"
+              placeholder="Search domains…"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="h-8 pl-8"
+              aria-label="Search scanned sites"
+            />
+          </div>
+          <p className="font-mono text-[11px] tabular-nums text-[var(--ui-ink-muted)]">
+            {filteredSites.length} {filteredSites.length === 1 ? 'site' : 'sites'}
+          </p>
+          <div
+            className="ml-auto flex rounded-[7px] bg-[var(--ui-paper)] p-0.5 shadow-[var(--shadow-control)]"
+            role="tablist"
+            aria-label="Sort options"
+          >
+            {(
+              [
+                ['votes', 'Popular'],
+                ['recent', 'Recent'],
+                ['tokens', 'Tokens'],
+              ] as const
+            ).map(([value, label]) => (
+              <button
+                key={value}
+                type="button"
+                role="tab"
+                aria-selected={sortBy === value}
+                onClick={() => setSortBy(value)}
+                className={cn(
+                  'h-7 rounded-[6px] px-2.5 text-[12px] transition-colors',
+                  sortBy === value
+                    ? 'bg-[var(--ui-paper-selected)] font-medium text-[var(--ui-ink)]'
+                    : 'text-[var(--ui-ink-secondary)] hover:text-[var(--ui-ink)]'
+                )}
               >
-                {(
-                  [
-                    ['votes', 'Popular'],
-                    ['recent', 'Recent'],
-                    ['tokens', 'Tokens'],
-                  ] as const
-                ).map(([value, label]) => (
-                  <button
-                    key={value}
-                    type="button"
-                    role="tab"
-                    aria-selected={sortBy === value}
-                    onClick={() => setSortBy(value)}
-                    className={cn(
-                      'px-3 py-1.5 text-xs transition-colors sm:text-sm',
-                      sortBy === value
-                        ? 'bg-secondary text-foreground'
-                        : 'text-muted-foreground hover:text-foreground'
-                    )}
-                  >
-                    {label}
-                  </button>
-                ))}
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Operational list */}
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          {loading ? (
+            <div className="flex flex-col" role="status" aria-label="Loading sites">
+              {Array.from({ length: 8 }).map((_, i) => (
+                <div
+                  key={i}
+                  className="h-11 animate-pulse border-b border-[var(--ui-border-soft)] bg-[var(--ui-paper-subtle)]/60"
+                />
+              ))}
+            </div>
+          ) : filteredSites.length === 0 ? (
+            <div className="mx-auto max-w-[712px] px-4 py-16 text-center">
+              <h2 className="text-lg font-semibold text-[var(--ui-ink)]">No sites yet</h2>
+              <p className="mx-auto mt-2 max-w-md text-[13px] text-[var(--ui-ink-secondary)]">
+                {searchQuery
+                  ? 'Nothing matched that search.'
+                  : 'Scan a public site and it will show up here.'}
+              </p>
+              <div className="mt-5 flex justify-center gap-2">
+                {searchQuery ? (
+                  <Button variant="outline" size="sm" onClick={() => setSearchQuery('')}>
+                    Clear search
+                  </Button>
+                ) : null}
+                <Button asChild size="sm">
+                  <Link href="/">Open chat</Link>
+                </Button>
               </div>
             </div>
-          </section>
-
-          <section className="px-4 py-6 sm:px-6 sm:py-8">
-            <div className="mx-auto max-w-3xl">
-              {loading ? (
-                <div className="flex flex-col gap-2" role="status" aria-label="Loading sites">
-                  {Array.from({ length: 6 }).map((_, i) => (
-                    <div
-                      key={i}
-                      className="h-16 animate-pulse rounded-2xl border border-[color:var(--soft-border)] bg-muted/20"
+          ) : (
+            <ul className="flex flex-col">
+              {filteredSites.map((site) => (
+                <li
+                  key={site.id}
+                  className="group flex min-h-11 items-center gap-3 border-b border-[var(--ui-border-soft)] px-3 transition-colors hover:bg-[var(--ui-paper-hover)] sm:px-4"
+                >
+                  {site.favicon ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={site.favicon}
+                      alt=""
+                      className="size-6 shrink-0 rounded-[4px] border border-[var(--ui-border-soft)] bg-[var(--ui-paper)] object-cover"
                     />
-                  ))}
-                </div>
-              ) : filteredSites.length === 0 ? (
-                <div className="rounded-2xl border border-[color:var(--soft-border)] bg-card/40 px-6 py-16 text-center">
-                  <h2 className="font-normal tracking-tight text-2xl text-foreground">No sites yet</h2>
-                  <p className="mx-auto mt-2 max-w-md text-sm text-muted-foreground">
-                    {searchQuery
-                      ? 'Nothing matched that search.'
-                      : 'Scan a public site and it will show up here.'}
-                  </p>
-                  <div className="mt-6 flex justify-center gap-2">
-                    {searchQuery ? (
-                      <Button variant="outline" onClick={() => setSearchQuery('')}>
-                        Clear search
-                      </Button>
-                    ) : null}
-                    <Button asChild>
-                      <Link href="/">Open chat</Link>
-                    </Button>
-                  </div>
-                </div>
-              ) : (
-                <ul className="flex flex-col gap-2">
-                  {filteredSites.map((site) => (
-                    <li
-                      key={site.id}
-                      className="group flex flex-col gap-4 rounded-2xl border border-[color:var(--soft-border)] bg-card/40 px-4 py-4 transition-colors hover:bg-card/70 sm:flex-row sm:items-center sm:justify-between sm:px-5"
+                  ) : (
+                    <div
+                      className="flex size-6 shrink-0 items-center justify-center rounded-[4px] border border-[var(--ui-border-soft)] bg-[var(--ui-paper-subtle)] font-mono text-[9px] text-[var(--ui-ink-muted)]"
+                      aria-hidden
                     >
-                      <div className="flex min-w-0 items-start gap-3 sm:items-center">
-                        {site.favicon ? (
-                          // eslint-disable-next-line @next/next/no-img-element
-                          <img
-                            src={site.favicon}
-                            alt=""
-                            className="mt-0.5 h-8 w-8 shrink-0 border border-[color:var(--soft-border)] bg-background object-cover sm:mt-0"
-                          />
-                        ) : (
-                          <div
-                            className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center border border-[color:var(--soft-border)] bg-muted/40 font-mono text-[10px] text-muted-foreground sm:mt-0"
-                            aria-hidden
-                          >
-                            {site.domain.slice(0, 2).toUpperCase()}
-                          </div>
-                        )}
-                        <div className="min-w-0">
-                          <Link
-                            href={`/site/${site.domain}`}
-                            className="font-normal tracking-tight text-xl tracking-tight text-foreground transition-colors hover:text-[oklch(0.78_0.08_185)]"
-                          >
-                            {site.title || site.domain}
-                          </Link>
-                          <p className="truncate font-mono text-[11px] text-muted-foreground">
-                            {site.domain}
-                          </p>
-                          {site.description ? (
-                            <p className="mt-1 line-clamp-1 text-sm text-muted-foreground">
-                              {site.description}
-                            </p>
-                          ) : null}
-                          <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 font-mono text-[11px] text-muted-foreground">
-                            <span className="inline-flex items-center gap-1">
-                              <Sparkles className="h-3 w-3" aria-hidden />
-                              {site.tokensCount} tokens
-                            </span>
-                            <span className="inline-flex items-center gap-1">
-                              <Clock className="h-3 w-3" aria-hidden />
-                              {formatTimeAgo(site.lastScanned)}
-                            </span>
-                          </div>
-                        </div>
-                      </div>
+                      {site.domain.slice(0, 2).toUpperCase()}
+                    </div>
+                  )}
 
-                      <div className="flex shrink-0 items-center gap-2 self-end sm:self-center">
-                        <button
-                          type="button"
-                          onClick={() => void handleVote(site.id)}
-                          disabled={site.hasVoted || votingId === site.id}
-                          className={cn(
-                            'inline-flex h-9 items-center gap-1.5 border px-2.5 font-mono text-xs transition-colors',
-                            site.hasVoted
-                              ? 'border-[oklch(0.78_0.08_185_/0.45)] bg-[oklch(0.78_0.08_185_/0.08)] text-[oklch(0.78_0.08_185)]'
-                              : 'border-[color:var(--soft-border)] text-muted-foreground hover:border-foreground/30 hover:text-foreground'
-                          )}
-                          aria-label={`Vote for ${site.domain}`}
-                          aria-pressed={site.hasVoted}
-                        >
-                          <ArrowUp className={cn('h-3.5 w-3.5', site.hasVoted && 'fill-current')} />
-                          {site.votes}
-                        </button>
-                        <Button asChild size="sm" variant="outline" className="h-9 rounded-md">
-                          <Link href={`/site/${site.domain}`}>View</Link>
-                        </Button>
-                        <Button asChild size="sm" variant="ghost" className="h-9 w-9 rounded-md px-0">
-                          <a
-                            href={`https://${site.domain}`}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            aria-label={`Visit ${site.domain}`}
-                          >
-                            <ExternalLink className="h-3.5 w-3.5" />
-                          </a>
-                        </Button>
-                      </div>
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </div>
-          </section>
+                  <div className="flex min-w-0 flex-1 items-baseline gap-2">
+                    <Link
+                      href={`/site/${site.domain}`}
+                      className="truncate text-[13px] font-medium text-[var(--ui-ink)] hover:text-[var(--ui-accent)]"
+                    >
+                      {site.title || site.domain}
+                    </Link>
+                    <span className="hidden shrink-0 font-mono text-[11px] text-[var(--ui-ink-muted)] sm:inline">
+                      {site.domain}
+                    </span>
+                  </div>
+
+                  <span className="hidden items-center gap-1 font-mono text-[11px] tabular-nums text-[var(--ui-ink-muted)] md:inline-flex">
+                    <Sparkles className="size-3" aria-hidden />
+                    {site.tokensCount}
+                  </span>
+                  <span className="hidden items-center gap-1 font-mono text-[11px] text-[var(--ui-ink-muted)] lg:inline-flex">
+                    <Clock className="size-3" aria-hidden />
+                    {formatTimeAgo(site.lastScanned)}
+                  </span>
+
+                  <button
+                    type="button"
+                    onClick={() => void handleVote(site.id)}
+                    disabled={site.hasVoted || votingId === site.id}
+                    className={cn(
+                      'inline-flex h-7 items-center gap-1 rounded-[7px] px-2 font-mono text-[11px] tabular-nums shadow-[var(--shadow-control)] transition',
+                      site.hasVoted
+                        ? 'bg-[var(--ui-accent-soft)] text-[var(--ui-accent)]'
+                        : 'bg-[var(--ui-paper)] text-[var(--ui-ink-secondary)] hover:bg-[var(--ui-paper-hover)] hover:text-[var(--ui-ink)]'
+                    )}
+                    aria-label={`Vote for ${site.domain}`}
+                    aria-pressed={site.hasVoted}
+                  >
+                    <ArrowUp className={cn('size-3', site.hasVoted && 'fill-current')} />
+                    {site.votes}
+                  </button>
+
+                  <Button asChild size="sm" variant="outline">
+                    <Link href={`/site/${site.domain}`}>Open</Link>
+                  </Button>
+                  <Button asChild size="icon-sm" variant="ghost">
+                    <a
+                      href={`https://${site.domain}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      aria-label={`Visit ${site.domain}`}
+                    >
+                      <ExternalLink className="size-3.5" />
+                    </a>
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
       </div>
     </AppShell>
   )

--- a/app/(marketing)/community/client.tsx
+++ b/app/(marketing)/community/client.tsx
@@ -121,7 +121,7 @@ export default function CommunityClient() {
       <div className="min-h-0 flex-1 overflow-y-auto" role="region" aria-label="Design Contracts library">
           <section className="border-b border-[color:var(--soft-border)] px-4 pb-6 pt-8 sm:px-6">
             <div className="mx-auto max-w-3xl">
-              <h1 className="font-serif text-3xl tracking-tight text-foreground">Library</h1>
+              <h1 className="font-normal tracking-tight text-3xl tracking-tight text-foreground">Library</h1>
               <p className="mt-2 max-w-xl text-sm text-muted-foreground">
                 Design Contracts from public sites. Open one, or ask Chat to gather a new system.
               </p>
@@ -194,7 +194,7 @@ export default function CommunityClient() {
                 </div>
               ) : filteredSites.length === 0 ? (
                 <div className="rounded-2xl border border-[color:var(--soft-border)] bg-card/40 px-6 py-16 text-center">
-                  <h2 className="font-serif text-2xl text-foreground">No sites yet</h2>
+                  <h2 className="font-normal tracking-tight text-2xl text-foreground">No sites yet</h2>
                   <p className="mx-auto mt-2 max-w-md text-sm text-muted-foreground">
                     {searchQuery
                       ? 'Nothing matched that search.'
@@ -237,7 +237,7 @@ export default function CommunityClient() {
                         <div className="min-w-0">
                           <Link
                             href={`/site/${site.domain}`}
-                            className="font-serif text-xl tracking-tight text-foreground transition-colors hover:text-[oklch(0.78_0.08_185)]"
+                            className="font-normal tracking-tight text-xl tracking-tight text-foreground transition-colors hover:text-[oklch(0.78_0.08_185)]"
                           >
                             {site.title || site.domain}
                           </Link>

--- a/app/(marketing)/contact/page.tsx
+++ b/app/(marketing)/contact/page.tsx
@@ -30,7 +30,7 @@ export default function ContactPage() {
   return (
     <AppShell currentPage="contact">
       <PageCanvas>
-        <h1 className="font-serif text-3xl tracking-tight text-foreground sm:text-4xl">
+        <h1 className="font-normal tracking-tight text-3xl tracking-tight text-foreground sm:text-4xl">
           Contact
         </h1>
         <p className="mt-2 text-[15px] leading-relaxed text-muted-foreground">

--- a/app/(marketing)/contact/page.tsx
+++ b/app/(marketing)/contact/page.tsx
@@ -1,296 +1,72 @@
-import { Metadata } from "next"
-import {
-  Mail,
-  MessageSquare,
-  HelpCircle,
-  Building2,
-  Shield,
-  Bug,
-  Lightbulb,
-  Users
-} from "lucide-react"
-import { MarketingHeader } from "@/components/organisms/marketing-header"
-import { MarketingFooter } from "@/components/organisms/marketing-footer"
-import { Card, CardContent, CardHeader } from "@/components/ui/card"
-import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Textarea } from "@/components/ui/textarea"
-import { Label } from "@/components/ui/label"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { AppShell } from '@/components/organisms/app-shell'
+import { PageCanvas } from '@/components/molecules/page-canvas'
 
 export const metadata: Metadata = {
-  title: "Contact - designcontracts.sh",
-  description: "Get in touch with the designcontracts.sh team. Support, sales, partnerships, and general inquiries welcome.",
-  openGraph: {
-    title: "Contact - designcontracts.sh",
-    description: "Get in touch with our team",
-  },
+  title: 'Contact — designcontracts.sh',
+  description: 'Get in touch with the designcontracts.sh team.',
 }
 
-const contactTypes = [
+const channels = [
   {
-    icon: HelpCircle,
-    title: "General Support",
-    description: "Questions about features, usage, or getting started",
-    email: "support@designcontracts.sh",
-    response: "Usually within 24 hours"
+    title: 'Support',
+    email: 'support@designcontracts.sh',
+    body: 'Product questions, scan issues, getting started.',
   },
   {
-    icon: Building2,
-    title: "Sales & Enterprise",
-    description: "Enterprise plans, custom integrations, and partnerships",
-    email: "sales@designcontracts.sh",
-    response: "Usually within 4 hours"
+    title: 'Sales & enterprise',
+    email: 'sales@designcontracts.sh',
+    body: 'Team plans, volume, and partnerships.',
   },
   {
-    icon: Bug,
-    title: "Bug Reports",
-    description: "Found a bug or technical issue? Let us know",
-    email: "bugs@designcontracts.sh",
-    response: "Usually within 12 hours"
+    title: 'Privacy & removal',
+    email: 'legal@designcontracts.sh',
+    body: 'Opt-out, GDPR, and directory removal requests.',
   },
-  {
-    icon: Shield,
-    title: "Privacy & Legal",
-    description: "GDPR requests, website removal, legal questions",
-    email: "legal@designcontracts.sh",
-    response: "Usually within 48 hours"
-  },
-  {
-    icon: Lightbulb,
-    title: "Feature Requests",
-    description: "Ideas for new features or improvements",
-    email: "features@designcontracts.sh",
-    response: "Usually within 1 week"
-  },
-  {
-    icon: Users,
-    title: "Community",
-    description: "Join our community discussions and get help from other users",
-    email: "community@designcontracts.sh",
-    response: "Join our Discord server"
-  }
-]
-
-const faqs = [
-  {
-    question: "How do I remove my website from your directory?",
-    answer: "You can request removal by emailing legal@designcontracts.sh or by adding 'designcontracts.sh' to your robots.txt disallow list. We'll process removal requests within 48 hours."
-  },
-  {
-    question: "Can I get enterprise pricing?",
-    answer: "Yes! Enterprise plans include custom integrations, on-premises deployment, SLA guarantees, and dedicated support. Contact our sales team for a quote."
-  },
-  {
-    question: "Do you offer refunds?",
-    answer: "We offer a 14-day money-back guarantee for all paid plans. Contact support if you're not satisfied with our service."
-  },
-  {
-    question: "How can I contribute to designcontracts.sh?",
-    answer: "We welcome contributions! You can report bugs, suggest features, contribute to our open-source components, or join our community discussions."
-  }
-]
+] as const
 
 export default function ContactPage() {
   return (
-    <>
-      <MarketingHeader currentPage="contact" showSearch={true} />
+    <AppShell currentPage="contact">
+      <PageCanvas>
+        <h1 className="font-serif text-3xl tracking-tight text-foreground sm:text-4xl">
+          Contact
+        </h1>
+        <p className="mt-2 text-[15px] leading-relaxed text-muted-foreground">
+          Reach the team directly — no ticket maze.
+        </p>
 
-      <main className="min-h-screen bg-background">
-        {/* Hero Section */}
-        <section className="py-20 px-4">
-          <div className="max-w-4xl mx-auto text-center">
-            <h1 className="text-4xl md:text-6xl font-bold tracking-tight mb-6">
-              Get in{" "}
-              <span className="text-blue-600 dark:text-blue-400">touch</span>
-            </h1>
-            <p className="text-xl text-muted-foreground mb-8 max-w-2xl mx-auto">
-              Have questions, feedback, or need help? We're here to support you.
-              Choose the best way to reach our team.
-            </p>
-          </div>
-        </section>
+        <div className="mt-12 space-y-8">
+          {channels.map((channel) => (
+            <section
+              key={channel.email}
+              className="border-t border-[color:var(--soft-border)] pt-6 first:border-t-0 first:pt-0"
+            >
+              <h2 className="text-[15px] font-medium text-foreground">{channel.title}</h2>
+              <p className="mt-1 text-sm text-muted-foreground">{channel.body}</p>
+              <a
+                href={`mailto:${channel.email}`}
+                className="mt-2 inline-block font-mono text-sm text-foreground underline-offset-4 hover:underline"
+              >
+                {channel.email}
+              </a>
+            </section>
+          ))}
+        </div>
 
-        {/* Contact Methods */}
-        <section className="py-16 px-4">
-          <div className="max-w-6xl mx-auto">
-            <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {contactTypes.map((contact) => (
-                <Card key={contact.title} className="border-muted">
-                  <CardHeader>
-                    <contact.icon className="h-8 w-8 text-blue-600 dark:text-blue-400 mb-2" />
-                    <h3 className="font-semibold">{contact.title}</h3>
-                    <p className="text-muted-foreground text-sm">{contact.description}</p>
-                  </CardHeader>
-                  <CardContent className="pt-0">
-                    <div className="space-y-3">
-                      <div>
-                        <div className="text-sm font-medium">Email</div>
-                        <a
-                          href={`mailto:${contact.email}`}
-                          className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
-                        >
-                          {contact.email}
-                        </a>
-                      </div>
-                      <div>
-                        <div className="text-sm font-medium">Response time</div>
-                        <div className="text-sm text-muted-foreground">{contact.response}</div>
-                      </div>
-                    </div>
-                  </CardContent>
-                </Card>
-              ))}
-            </div>
-          </div>
-        </section>
-
-        {/* Contact Form */}
-        <section className="py-16 px-4 bg-muted/30">
-          <div className="max-w-2xl mx-auto">
-            <div className="text-center mb-12">
-              <h2 className="text-3xl font-bold mb-4">Send us a message</h2>
-              <p className="text-muted-foreground">
-                Prefer to send a message? Fill out the form below and we'll get back to you.
-              </p>
-            </div>
-
-            <Card className="border-muted">
-              <CardContent className="p-6">
-                <form className="space-y-6">
-                  <div className="grid md:grid-cols-2 gap-4">
-                    <div>
-                      <Label htmlFor="name">Name</Label>
-                      <Input id="name" placeholder="Your name" className="mt-1" />
-                    </div>
-                    <div>
-                      <Label htmlFor="email">Email</Label>
-                      <Input id="email" type="email" placeholder="your.email@example.com" className="mt-1" />
-                    </div>
-                  </div>
-
-                  <div>
-                    <Label htmlFor="subject">Subject</Label>
-                    <Select>
-                      <SelectTrigger className="mt-1">
-                        <SelectValue placeholder="What's this about?" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="support">General Support</SelectItem>
-                        <SelectItem value="sales">Sales & Enterprise</SelectItem>
-                        <SelectItem value="bug">Bug Report</SelectItem>
-                        <SelectItem value="feature">Feature Request</SelectItem>
-                        <SelectItem value="legal">Privacy & Legal</SelectItem>
-                        <SelectItem value="other">Other</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
-
-                  <div>
-                    <Label htmlFor="company">Company (optional)</Label>
-                    <Input id="company" placeholder="Your company name" className="mt-1" />
-                  </div>
-
-                  <div>
-                    <Label htmlFor="message">Message</Label>
-                    <Textarea
-                      id="message"
-                      placeholder="Tell us how we can help..."
-                      className="mt-1 min-h-[120px]"
-                    />
-                  </div>
-
-                  <Button className="w-full bg-blue-600 hover:bg-blue-700">
-                    <Mail className="h-4 w-4 mr-2" />
-                    Send Message
-                  </Button>
-                </form>
-              </CardContent>
-            </Card>
-          </div>
-        </section>
-
-        {/* FAQ Section */}
-        <section className="py-16 px-4">
-          <div className="max-w-3xl mx-auto">
-            <div className="text-center mb-12">
-              <h2 className="text-3xl font-bold mb-4">Frequently asked questions</h2>
-              <p className="text-muted-foreground">
-                Quick answers to common questions
-              </p>
-            </div>
-
-            <div className="space-y-6">
-              {faqs.map((faq, index) => (
-                <Card key={index} className="border-muted">
-                  <CardContent className="p-6">
-                    <h3 className="font-semibold mb-2">{faq.question}</h3>
-                    <p className="text-muted-foreground">{faq.answer}</p>
-                  </CardContent>
-                </Card>
-              ))}
-            </div>
-          </div>
-        </section>
-
-        {/* Community Section */}
-        <section className="py-16 px-4 bg-muted/30">
-          <div className="max-w-4xl mx-auto text-center">
-            <h2 className="text-3xl font-bold mb-4">Join our community</h2>
-            <p className="text-muted-foreground mb-8 max-w-2xl mx-auto">
-              Connect with other developers, share your experiences, and get help from the community.
-            </p>
-
-            <div className="grid md:grid-cols-2 gap-6">
-              <Card className="border-muted">
-                <CardContent className="p-6">
-                  <MessageSquare className="h-8 w-8 text-blue-600 dark:text-blue-400 mx-auto mb-4" />
-                  <h3 className="font-semibold mb-2">Discord Community</h3>
-                  <p className="text-muted-foreground mb-4 text-sm">
-                    Join our Discord server for real-time discussions, help, and community support.
-                  </p>
-                  <Button variant="outline">Join Discord</Button>
-                </CardContent>
-              </Card>
-
-              <Card className="border-muted">
-                <CardContent className="p-6">
-                  <Users className="h-8 w-8 text-blue-600 dark:text-blue-400 mx-auto mb-4" />
-                  <h3 className="font-semibold mb-2">GitHub Discussions</h3>
-                  <p className="text-muted-foreground mb-4 text-sm">
-                    Participate in feature discussions, report issues, and contribute to our roadmap.
-                  </p>
-                  <Button variant="outline">View Discussions</Button>
-                </CardContent>
-              </Card>
-            </div>
-          </div>
-        </section>
-
-        {/* Emergency Contact */}
-        <section className="py-16 px-4">
-          <div className="max-w-2xl mx-auto">
-            <Card className="border-red-200 dark:border-red-800 bg-red-50/50 dark:bg-red-950/50">
-              <CardContent className="p-6 text-center">
-                <Shield className="h-8 w-8 text-red-600 dark:text-red-400 mx-auto mb-4" />
-                <h3 className="font-semibold mb-2">Security Issues or Emergencies</h3>
-                <p className="text-muted-foreground mb-4 text-sm">
-                  If you've discovered a security vulnerability or need immediate assistance with
-                  a critical issue, please contact us directly:
-                </p>
-                <a
-                  href="mailto:security@designcontracts.sh"
-                  className="text-red-600 dark:text-red-400 hover:underline font-medium"
-                >
-                  security@designcontracts.sh
-                </a>
-              </CardContent>
-            </Card>
-          </div>
-        </section>
-      </main>
-
-      <MarketingFooter />
-    </>
+        <p className="mt-12 text-sm text-muted-foreground">
+          Prefer to explore first?{' '}
+          <Link href="/" className="text-foreground underline-offset-4 hover:underline">
+            Open Chat
+          </Link>{' '}
+          or browse the{' '}
+          <Link href="/community" className="text-foreground underline-offset-4 hover:underline">
+            Library
+          </Link>
+          .
+        </p>
+      </PageCanvas>
+    </AppShell>
   )
 }

--- a/app/(marketing)/docs/page.tsx
+++ b/app/(marketing)/docs/page.tsx
@@ -33,19 +33,26 @@ export default function DocsPage() {
   return (
     <AppShell currentPage="docs">
       <div className="min-h-0 flex-1 overflow-y-auto">
-        <div className="mx-auto max-w-2xl px-4 py-10 sm:px-6 sm:py-12">
-          <h1 className="font-normal tracking-tight text-3xl tracking-tight text-foreground sm:text-4xl">Docs</h1>
-          <p className="mt-2 text-[15px] leading-relaxed text-muted-foreground">
+        <div className="mx-auto max-w-[760px] px-4 py-8 sm:px-6 sm:py-10">
+          <h1 className="text-[22px] font-semibold tracking-tight text-[var(--ui-ink)] sm:text-[26px]">
+            Docs
+          </h1>
+          <p className="mt-2 max-w-xl text-[15px] leading-relaxed text-[var(--ui-ink-secondary)]">
             Turn any public website into an installable Design Contract — tokens, layout DNA, a
             semantic graph, and agent-ready guidance.
           </p>
 
           <section className="mt-10 space-y-4">
-            <h2 className="text-sm font-medium tracking-tight text-foreground">Quick start</h2>
-            <ol className="list-decimal space-y-3 pl-5 text-sm text-muted-foreground">
+            <h2 className="text-[13px] font-semibold tracking-tight text-[var(--ui-ink)]">
+              Quick start
+            </h2>
+            <ol className="list-decimal space-y-2.5 pl-5 text-[13px] leading-relaxed text-[var(--ui-ink-secondary)]">
               <li>
                 Open{' '}
-                <Link href="/" className="text-foreground underline-offset-4 hover:underline">
+                <Link
+                  href="/"
+                  className="text-[var(--ui-ink)] underline-offset-4 hover:underline"
+                >
                   Chat
                 </Link>{' '}
                 and paste a public URL.
@@ -56,25 +63,28 @@ export default function DocsPage() {
               </li>
               <li>Download the pack and install it with the Design CLI.</li>
             </ol>
-            <pre className="overflow-x-auto rounded-2xl border border-[color:var(--soft-border)] bg-card/60 p-4 font-mono text-xs leading-relaxed">
+            <pre className="overflow-x-auto rounded-[10px] border border-[var(--ui-border)] bg-[var(--ui-paper-subtle)] p-3.5 font-mono text-[12px] leading-relaxed shadow-[var(--shadow-paper)]">
               {`npx --yes github:byronwade/Design init
 npx --yes github:byronwade/Design resolve --request "rebuild the hero"`}
             </pre>
           </section>
 
-          <section className="mt-12 space-y-5">
-            <h2 className="text-sm font-medium tracking-tight text-foreground">HTTP API</h2>
+          <section className="mt-12 space-y-3">
+            <h2 className="text-[13px] font-semibold tracking-tight text-[var(--ui-ink)]">
+              HTTP API
+            </h2>
             {endpoints.map((endpoint) => (
               <article
                 key={endpoint.path}
-                className="space-y-2 rounded-2xl border border-[color:var(--soft-border)] bg-card/40 px-4 py-4"
+                className="space-y-2 rounded-[10px] border border-[var(--ui-border)] bg-[var(--ui-paper)] px-3.5 py-3 shadow-[var(--shadow-paper)]"
               >
-                <p className="font-mono text-sm text-foreground">
-                  <span className="text-muted-foreground">{endpoint.method}</span> {endpoint.path}
+                <p className="font-mono text-[13px] text-[var(--ui-ink)]">
+                  <span className="text-[var(--ui-ink-muted)]">{endpoint.method}</span>{' '}
+                  {endpoint.path}
                 </p>
-                <p className="text-sm text-muted-foreground">{endpoint.note}</p>
+                <p className="text-[13px] text-[var(--ui-ink-secondary)]">{endpoint.note}</p>
                 {endpoint.body ? (
-                  <pre className="overflow-x-auto rounded-xl bg-muted/40 p-3 font-mono text-xs">
+                  <pre className="overflow-x-auto rounded-[8px] bg-[var(--ui-paper-subtle)] p-2.5 font-mono text-[11px]">
                     {endpoint.body}
                   </pre>
                 ) : null}
@@ -83,15 +93,17 @@ npx --yes github:byronwade/Design resolve --request "rebuild the hero"`}
           </section>
 
           <section className="mt-12 space-y-3">
-            <h2 className="text-sm font-medium tracking-tight text-foreground">Chat agent</h2>
-            <p className="text-sm text-muted-foreground">
+            <h2 className="text-[13px] font-semibold tracking-tight text-[var(--ui-ink)]">
+              Chat agent
+            </h2>
+            <p className="text-[13px] leading-relaxed text-[var(--ui-ink-secondary)]">
               Chat uses the Vercel AI SDK + AI Gateway (`ToolLoopAgent`) with tools{' '}
-              <code className="text-foreground">scan_site</code>,{' '}
-              <code className="text-foreground">get_tokens</code>,{' '}
-              <code className="text-foreground">resolve_graph</code>, and{' '}
-              <code className="text-foreground">get_contract_download</code>.
+              <code className="text-[var(--ui-ink)]">scan_site</code>,{' '}
+              <code className="text-[var(--ui-ink)]">get_tokens</code>,{' '}
+              <code className="text-[var(--ui-ink)]">resolve_graph</code>, and{' '}
+              <code className="text-[var(--ui-ink)]">get_contract_download</code>.
             </p>
-            <pre className="overflow-x-auto rounded-2xl border border-[color:var(--soft-border)] bg-card/60 p-4 font-mono text-xs leading-relaxed">
+            <pre className="overflow-x-auto rounded-[10px] border border-[var(--ui-border)] bg-[var(--ui-paper-subtle)] p-3.5 font-mono text-[12px] leading-relaxed shadow-[var(--shadow-paper)]">
               {`POST /api/agent/chat
 { "messages": [ /* UIMessage[] from useChat */ ] }
 
@@ -102,10 +114,12 @@ SCANNER_SERVICE_URL=https://designcontracts-scanner.vercel.app`}
           </section>
 
           <section className="mt-12 space-y-3 pb-16">
-            <h2 className="text-sm font-medium tracking-tight text-foreground">Accurate scans</h2>
-            <p className="text-sm text-muted-foreground">
-              When <code className="text-foreground">SCANNER_SERVICE_URL</code> is set, chat defaults
-              to accurate browser capture via the Vercel Chromium scanner.
+            <h2 className="text-[13px] font-semibold tracking-tight text-[var(--ui-ink)]">
+              Accurate scans
+            </h2>
+            <p className="text-[13px] leading-relaxed text-[var(--ui-ink-secondary)]">
+              When <code className="text-[var(--ui-ink)]">SCANNER_SERVICE_URL</code> is set, chat
+              defaults to accurate browser capture via the Vercel Chromium scanner.
             </p>
           </section>
         </div>

--- a/app/(marketing)/docs/page.tsx
+++ b/app/(marketing)/docs/page.tsx
@@ -34,7 +34,7 @@ export default function DocsPage() {
     <AppShell currentPage="docs">
       <div className="min-h-0 flex-1 overflow-y-auto">
         <div className="mx-auto max-w-2xl px-4 py-10 sm:px-6 sm:py-12">
-          <h1 className="font-serif text-3xl tracking-tight text-foreground sm:text-4xl">Docs</h1>
+          <h1 className="font-normal tracking-tight text-3xl tracking-tight text-foreground sm:text-4xl">Docs</h1>
           <p className="mt-2 text-[15px] leading-relaxed text-muted-foreground">
             Turn any public website into an installable Design Contract — tokens, layout DNA, a
             semantic graph, and agent-ready guidance.

--- a/app/(marketing)/features/page.tsx
+++ b/app/(marketing)/features/page.tsx
@@ -43,38 +43,40 @@ const features = [
 export default function FeaturesPage() {
   return (
     <AppShell currentPage="features">
-      <PageCanvas>
-        <h1 className="font-normal tracking-tight text-3xl tracking-tight text-foreground sm:text-4xl">
+      <PageCanvas variant="document">
+        <h1 className="text-[22px] font-semibold tracking-tight text-[var(--ui-ink)] sm:text-[26px]">
           Features
         </h1>
-        <p className="mt-2 text-[15px] leading-relaxed text-muted-foreground">
+        <p className="mt-2 max-w-xl text-[15px] leading-relaxed text-[var(--ui-ink-secondary)]">
           Turn a live site into AI-readable design context — without dashboard clutter.
         </p>
 
-        <div className="mt-12 space-y-10">
+        <div className="mt-10 space-y-8">
           {features.map((feature) => (
             <section
               key={feature.title}
-              className="border-t border-[color:var(--soft-border)] pt-8 first:border-t-0 first:pt-0"
+              className="border-t border-[var(--ui-border-soft)] pt-6 first:border-t-0 first:pt-0"
             >
-              <h2 className="text-[15px] font-medium tracking-tight text-foreground">
+              <h2 className="text-[14px] font-semibold tracking-tight text-[var(--ui-ink)]">
                 {feature.title}
               </h2>
-              <p className="mt-2 text-sm leading-relaxed text-muted-foreground">{feature.body}</p>
+              <p className="mt-1.5 text-[13px] leading-relaxed text-[var(--ui-ink-secondary)]">
+                {feature.body}
+              </p>
             </section>
           ))}
         </div>
 
-        <div className="mt-14 flex flex-wrap gap-3">
+        <div className="mt-12 flex flex-wrap gap-2">
           <Link
             href="/"
-            className="inline-flex h-10 items-center rounded-xl bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90"
+            className="inline-flex h-8 items-center rounded-[7px] bg-[var(--ui-accent)] px-2.5 text-[13px] font-medium text-[var(--ui-paper)] shadow-[var(--shadow-control-primary)] transition hover:bg-[var(--ui-accent-hover)]"
           >
             Open Chat
           </Link>
           <Link
             href="/docs"
-            className="inline-flex h-10 items-center rounded-xl border border-[color:var(--soft-border)] px-4 text-sm font-medium text-foreground transition hover:bg-muted/40"
+            className="inline-flex h-8 items-center rounded-[7px] bg-[var(--ui-paper)] px-2.5 text-[13px] font-medium text-[var(--ui-ink)] shadow-[var(--shadow-control)] transition hover:bg-[var(--ui-paper-hover)]"
           >
             Read the docs
           </Link>

--- a/app/(marketing)/features/page.tsx
+++ b/app/(marketing)/features/page.tsx
@@ -44,7 +44,7 @@ export default function FeaturesPage() {
   return (
     <AppShell currentPage="features">
       <PageCanvas>
-        <h1 className="font-serif text-3xl tracking-tight text-foreground sm:text-4xl">
+        <h1 className="font-normal tracking-tight text-3xl tracking-tight text-foreground sm:text-4xl">
           Features
         </h1>
         <p className="mt-2 text-[15px] leading-relaxed text-muted-foreground">
@@ -68,7 +68,7 @@ export default function FeaturesPage() {
         <div className="mt-14 flex flex-wrap gap-3">
           <Link
             href="/"
-            className="inline-flex h-10 items-center rounded-xl bg-foreground px-4 text-sm font-medium text-background transition hover:opacity-90"
+            className="inline-flex h-10 items-center rounded-xl bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90"
           >
             Open Chat
           </Link>

--- a/app/(marketing)/features/page.tsx
+++ b/app/(marketing)/features/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
-import { MarketingFooter } from '@/components/organisms/marketing-footer'
-import { VercelHeader } from '@/components/organisms/vercel-header'
+import { AppShell } from '@/components/organisms/app-shell'
+import { PageCanvas } from '@/components/molecules/page-canvas'
 
 export const metadata: Metadata = {
   title: 'Features — designcontracts.sh',
@@ -20,7 +20,7 @@ const features = [
   },
   {
     title: 'Fast + accurate modes',
-    body: 'Fast uses static CSS for Hobby-friendly latency. Accurate adds Docker Playwright capture when SCANNER_SERVICE_URL is set.',
+    body: 'Fast uses static CSS for Hobby-friendly latency. Accurate adds the Vercel Chromium scanner when SCANNER_SERVICE_URL is set.',
   },
   {
     title: 'Wallace-aware tokenization',
@@ -42,46 +42,44 @@ const features = [
 
 export default function FeaturesPage() {
   return (
-    <div className="min-h-screen bg-background">
-      <VercelHeader currentPage="features" />
-      <main className="mx-auto max-w-3xl px-4 py-16 sm:px-6">
-        <p className="text-sm text-muted-foreground">Features</p>
-        <h1 className="mt-2 font-serif text-4xl tracking-tight text-foreground sm:text-5xl">
-          designcontracts.sh
+    <AppShell currentPage="features">
+      <PageCanvas>
+        <h1 className="font-serif text-3xl tracking-tight text-foreground sm:text-4xl">
+          Features
         </h1>
-        <p className="mt-4 text-lg text-muted-foreground">
-          Everything needed to turn a live site into AI-readable design context — without the old
-          Design Contracts dashboard clutter.
+        <p className="mt-2 text-[15px] leading-relaxed text-muted-foreground">
+          Turn a live site into AI-readable design context — without dashboard clutter.
         </p>
 
-        <div className="mt-14 space-y-10">
+        <div className="mt-12 space-y-10">
           {features.map((feature) => (
             <section
               key={feature.title}
-              className="border-t border-border/60 pt-8 first:border-t-0 first:pt-0"
+              className="border-t border-[color:var(--soft-border)] pt-8 first:border-t-0 first:pt-0"
             >
-              <h2 className="text-xl font-semibold text-foreground">{feature.title}</h2>
-              <p className="mt-2 text-muted-foreground">{feature.body}</p>
+              <h2 className="text-[15px] font-medium tracking-tight text-foreground">
+                {feature.title}
+              </h2>
+              <p className="mt-2 text-sm leading-relaxed text-muted-foreground">{feature.body}</p>
             </section>
           ))}
         </div>
 
-        <div className="mt-16 flex flex-wrap gap-3">
+        <div className="mt-14 flex flex-wrap gap-3">
           <Link
             href="/"
-            className="inline-flex h-11 items-center rounded-md bg-foreground px-5 text-sm font-medium text-background"
+            className="inline-flex h-10 items-center rounded-xl bg-foreground px-4 text-sm font-medium text-background transition hover:opacity-90"
           >
-            Open Scan
+            Open Chat
           </Link>
           <Link
             href="/docs"
-            className="inline-flex h-11 items-center rounded-md border border-border px-5 text-sm font-medium text-foreground"
+            className="inline-flex h-10 items-center rounded-xl border border-[color:var(--soft-border)] px-4 text-sm font-medium text-foreground transition hover:bg-muted/40"
           >
             Read the docs
           </Link>
         </div>
-      </main>
-      <MarketingFooter />
-    </div>
+      </PageCanvas>
+    </AppShell>
   )
 }

--- a/app/(marketing)/metrics/page.tsx
+++ b/app/(marketing)/metrics/page.tsx
@@ -10,8 +10,8 @@ import { LiveActivityFeed } from "@/components/molecules/live-activity-feed"
 import { LiveMetricsDashboard } from "@/components/molecules/live-metrics-dashboard"
 import { LiveScanQueue } from "@/components/molecules/live-scan-queue"
 import { LiveUserPresence } from "@/components/molecules/live-user-presence"
-import { MarketingHeader } from "@/components/organisms/marketing-header"
-import { MarketingFooter } from "@/components/organisms/marketing-footer"
+import { AppShell } from "@/components/organisms/app-shell"
+import { PageCanvas } from "@/components/molecules/page-canvas"
 
 interface RealtimeStats {
   page_views: number
@@ -178,15 +178,13 @@ export default function MetricsPage() {
   const maxValue = Math.max(...timeSeriesData.map(d => d.value), 1)
 
   return (
-    <div className="flex min-h-screen flex-col bg-background">
-      <MarketingHeader currentPage="metrics" showSearch={true} />
-
-      <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+    <AppShell currentPage="metrics">
+      <PageCanvas innerClassName="max-w-6xl px-4 py-8 sm:px-6">
         {/* Page Header with Live Status */}
         <div className="flex items-center justify-between mb-8">
           <div>
-            <h1 className="text-2xl font-bold text-foreground">Real-Time Metrics</h1>
-            <p className="text-sm text-grep-9 mt-1">Live platform performance and usage analytics</p>
+            <h1 className="font-serif text-3xl tracking-tight text-foreground">Metrics</h1>
+            <p className="text-sm text-muted-foreground mt-1">Live platform performance and usage analytics</p>
           </div>
 
           {/* Connection Status */}
@@ -520,10 +518,8 @@ export default function MetricsPage() {
             </div>
           </div>
         </div>
-      </div>
-
-      <MarketingFooter />
-    </div>
+      </PageCanvas>
+    </AppShell>
   )
 }
 

--- a/app/(marketing)/metrics/page.tsx
+++ b/app/(marketing)/metrics/page.tsx
@@ -183,7 +183,7 @@ export default function MetricsPage() {
         {/* Page Header with Live Status */}
         <div className="flex items-center justify-between mb-8">
           <div>
-            <h1 className="font-serif text-3xl tracking-tight text-foreground">Metrics</h1>
+            <h1 className="font-normal tracking-tight text-3xl tracking-tight text-foreground">Metrics</h1>
             <p className="text-sm text-muted-foreground mt-1">Live platform performance and usage analytics</p>
           </div>
 

--- a/app/(marketing)/pricing/page.tsx
+++ b/app/(marketing)/pricing/page.tsx
@@ -6,7 +6,8 @@ import { cn } from '@/lib/utils'
 
 export const metadata: Metadata = {
   title: 'Pricing — designcontracts.sh',
-  description: 'Simple pricing for Design Contract extraction. Start free, scale when you need API volume.',
+  description:
+    'Simple pricing for Design Contract extraction. Start free, scale when you need API volume.',
 }
 
 const plans = [
@@ -58,44 +59,47 @@ const plans = [
 export default function PricingPage() {
   return (
     <AppShell currentPage="pricing">
-      <PageCanvas innerClassName="max-w-4xl">
-        <h1 className="font-normal tracking-tight text-3xl tracking-tight text-foreground sm:text-4xl">
+      <PageCanvas variant="document" innerClassName="max-w-4xl">
+        <h1 className="text-[22px] font-semibold tracking-tight text-[var(--ui-ink)] sm:text-[26px]">
           Pricing
         </h1>
-        <p className="mt-2 max-w-xl text-[15px] leading-relaxed text-muted-foreground">
+        <p className="mt-2 max-w-xl text-[15px] leading-relaxed text-[var(--ui-ink-secondary)]">
           Start free in Chat. Upgrade when you need volume, API, or team features.
         </p>
 
-        <div className="mt-12 grid gap-4 md:grid-cols-3">
+        <div className="mt-10 grid gap-3 md:grid-cols-3">
           {plans.map((plan) => (
             <div
               key={plan.name}
               className={cn(
-                'flex flex-col rounded-2xl border border-[color:var(--soft-border)] bg-card/40 p-5',
-                plan.highlighted && 'bg-card/80 ring-1 ring-foreground/10'
+                'flex flex-col rounded-[10px] border border-[var(--ui-border)] bg-[var(--ui-paper)] p-4 shadow-[var(--shadow-paper)]',
+                plan.highlighted && 'border-[var(--ui-border-edge)] bg-[var(--ui-paper)] ring-1 ring-[var(--ui-accent)]/20'
               )}
             >
               <div className="flex items-baseline justify-between gap-2">
-                <h2 className="text-sm font-medium text-foreground">{plan.name}</h2>
+                <h2 className="text-[13px] font-semibold text-[var(--ui-ink)]">{plan.name}</h2>
                 {plan.highlighted ? (
-                  <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+                  <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[var(--ui-accent)]">
                     Popular
                   </span>
                 ) : null}
               </div>
               <p className="mt-3 flex items-baseline gap-1">
-                <span className="text-2xl font-semibold tracking-tight text-foreground">
+                <span className="text-2xl font-semibold tracking-tight text-[var(--ui-ink)] tabular-nums">
                   {plan.price}
                 </span>
                 {plan.period ? (
-                  <span className="text-xs text-muted-foreground">{plan.period}</span>
+                  <span className="text-[12px] text-[var(--ui-ink-muted)]">{plan.period}</span>
                 ) : null}
               </p>
-              <p className="mt-2 text-sm text-muted-foreground">{plan.description}</p>
-              <ul className="mt-5 flex-1 space-y-2 text-sm text-muted-foreground">
+              <p className="mt-2 text-[13px] text-[var(--ui-ink-secondary)]">{plan.description}</p>
+              <ul className="mt-4 flex-1 space-y-1.5 text-[13px] text-[var(--ui-ink-secondary)]">
                 {plan.features.map((feature) => (
                   <li key={feature} className="flex gap-2">
-                    <span className="mt-2 size-1 shrink-0 rounded-full bg-foreground/50" aria-hidden />
+                    <span
+                      className="mt-1.5 size-1 shrink-0 rounded-full bg-[var(--ui-ink-muted)]"
+                      aria-hidden
+                    />
                     {feature}
                   </li>
                 ))}
@@ -103,10 +107,10 @@ export default function PricingPage() {
               <Link
                 href={plan.cta.href}
                 className={cn(
-                  'mt-6 inline-flex h-10 items-center justify-center rounded-xl text-sm font-medium transition',
+                  'mt-5 inline-flex h-8 items-center justify-center rounded-[7px] text-[13px] font-medium transition',
                   plan.highlighted
-                    ? 'bg-primary text-primary-foreground hover:bg-[var(--primary-active)]'
-                    : 'border border-[color:var(--soft-border)] text-foreground hover:bg-muted/40'
+                    ? 'bg-[var(--ui-accent)] text-[var(--ui-paper)] shadow-[var(--shadow-control-primary)] hover:bg-[var(--ui-accent-hover)]'
+                    : 'bg-[var(--ui-paper)] text-[var(--ui-ink)] shadow-[var(--shadow-control)] hover:bg-[var(--ui-paper-hover)]'
                 )}
               >
                 {plan.cta.label}
@@ -115,9 +119,12 @@ export default function PricingPage() {
           ))}
         </div>
 
-        <p className="mt-10 text-sm text-muted-foreground">
+        <p className="mt-8 text-[13px] text-[var(--ui-ink-secondary)]">
           Questions?{' '}
-          <Link href="/contact" className="text-foreground underline-offset-4 hover:underline">
+          <Link
+            href="/contact"
+            className="text-[var(--ui-ink)] underline-offset-4 hover:underline"
+          >
             Contact us
           </Link>
           .

--- a/app/(marketing)/pricing/page.tsx
+++ b/app/(marketing)/pricing/page.tsx
@@ -59,7 +59,7 @@ export default function PricingPage() {
   return (
     <AppShell currentPage="pricing">
       <PageCanvas innerClassName="max-w-4xl">
-        <h1 className="font-serif text-3xl tracking-tight text-foreground sm:text-4xl">
+        <h1 className="font-normal tracking-tight text-3xl tracking-tight text-foreground sm:text-4xl">
           Pricing
         </h1>
         <p className="mt-2 max-w-xl text-[15px] leading-relaxed text-muted-foreground">
@@ -105,7 +105,7 @@ export default function PricingPage() {
                 className={cn(
                   'mt-6 inline-flex h-10 items-center justify-center rounded-xl text-sm font-medium transition',
                   plan.highlighted
-                    ? 'bg-foreground text-background hover:opacity-90'
+                    ? 'bg-primary text-primary-foreground hover:bg-[var(--primary-active)]'
                     : 'border border-[color:var(--soft-border)] text-foreground hover:bg-muted/40'
                 )}
               >

--- a/app/(marketing)/pricing/page.tsx
+++ b/app/(marketing)/pricing/page.tsx
@@ -1,344 +1,128 @@
-import { Metadata } from "next"
-import { Check, Star, Zap, Users, Building2 } from "lucide-react"
-import { MarketingHeader } from "@/components/organisms/marketing-header"
-import { MarketingFooter } from "@/components/organisms/marketing-footer"
-import { Card, CardContent, CardHeader } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { AppShell } from '@/components/organisms/app-shell'
+import { PageCanvas } from '@/components/molecules/page-canvas'
+import { cn } from '@/lib/utils'
 
 export const metadata: Metadata = {
-  title: "Pricing - designcontracts.sh",
-  description: "Simple, transparent pricing for design token extraction. Start free, upgrade as you grow.",
-  openGraph: {
-    title: "Pricing - designcontracts.sh",
-    description: "Simple pricing for AI-powered design token extraction",
-  },
+  title: 'Pricing — designcontracts.sh',
+  description: 'Simple pricing for Design Contract extraction. Start free, scale when you need API volume.',
 }
 
 const plans = [
   {
-    name: "Free",
-    price: "$0",
-    period: "forever",
-    description: "Perfect for exploring and small projects",
-    icon: Star,
+    name: 'Free',
+    price: '$0',
+    period: 'forever',
+    description: 'Explore chat scans and the public library.',
     features: [
-      "10 token extractions per month",
-      "Basic design token export",
-      "Community directory access",
-      "Standard CSS analysis",
-      "Public token sets only",
-      "Community support"
+      'Chat-based site scans',
+      'Installable contract packs',
+      'Library access',
+      'Community support',
     ],
-    limitations: [
-      "No layout DNA analysis",
-      "No private token sets",
-      "No API access",
-      "No priority support"
-    ],
-    cta: "Start free",
-    popular: false
+    cta: { href: '/', label: 'Open Chat' },
+    highlighted: false,
   },
   {
-    name: "Pro",
-    price: "$9.95",
-    period: "per month",
-    description: "For designers and developers building design systems",
-    icon: Zap,
+    name: 'Pro',
+    price: '$9.95',
+    period: '/ month',
+    description: 'Higher volume and API access for builders.',
     features: [
-      "Unlimited token extractions",
-      "Full layout DNA analysis",
-      "Private token sets",
-      "MCP API access",
-      "Advanced export formats",
-      "Version history & diffs",
-      "Priority email support",
-      "Custom token aliasing",
-      "Bulk operations",
-      "Webhook integrations"
+      'Unlimited chat scans',
+      'Accurate scanner mode',
+      'API + MCP access',
+      'Private contract storage',
+      'Priority support',
     ],
-    limitations: [],
-    cta: "Start Pro trial",
-    popular: true
+    cta: { href: '/contact', label: 'Talk to us' },
+    highlighted: true,
   },
   {
-    name: "Team",
-    price: "$29",
-    period: "per month",
-    description: "For teams collaborating on design systems",
-    icon: Users,
+    name: 'Team',
+    price: 'Custom',
+    period: '',
+    description: 'Shared workspaces and volume for orgs.',
     features: [
-      "Everything in Pro",
-      "Team workspaces",
-      "Collaborative features",
-      "Shared token libraries",
-      "Team analytics",
-      "Role-based permissions",
-      "SSO integration",
-      "Priority chat support",
-      "Team onboarding",
-      "Advanced security"
+      'Everything in Pro',
+      'Shared library',
+      'SSO / seat management',
+      'SLA options',
     ],
-    limitations: [],
-    cta: "Contact sales",
-    popular: false
+    cta: { href: '/contact', label: 'Contact sales' },
+    highlighted: false,
   },
-  {
-    name: "Enterprise",
-    price: "Custom",
-    period: "pricing",
-    description: "For large organizations with custom needs",
-    icon: Building2,
-    features: [
-      "Everything in Team",
-      "Custom integrations",
-      "On-premises deployment",
-      "SLA guarantees",
-      "Dedicated support",
-      "Custom training",
-      "Advanced analytics",
-      "Audit logging",
-      "Custom branding",
-      "Volume discounts"
-    ],
-    limitations: [],
-    cta: "Contact sales",
-    popular: false
-  }
-]
-
-const faqs = [
-  {
-    question: "What counts as a token extraction?",
-    answer: "A token extraction is analyzing one website/URL to generate design tokens. Each scan counts as one extraction, regardless of how many tokens are found."
-  },
-  {
-    question: "Can I cancel anytime?",
-    answer: "Yes, you can cancel your subscription at any time. You'll continue to have access to Pro features until the end of your billing period."
-  },
-  {
-    question: "What's included in the free plan?",
-    answer: "The free plan includes 10 monthly extractions, basic token export, and access to our community directory. Perfect for trying out the platform."
-  },
-  {
-    question: "Do you offer refunds?",
-    answer: "We offer a 14-day money-back guarantee for all paid plans. If you're not satisfied, we'll provide a full refund within the first 14 days."
-  },
-  {
-    question: "What payment methods do you accept?",
-    answer: "We accept all major credit cards (Visa, MasterCard, American Express) and PayPal. Enterprise customers can also pay by invoice."
-  },
-  {
-    question: "Is there a trial for paid plans?",
-    answer: "Yes! Pro and Team plans come with a 14-day free trial. No credit card required to start your trial."
-  }
-]
+] as const
 
 export default function PricingPage() {
   return (
-    <>
-      <MarketingHeader currentPage="pricing" showSearch={true} />
+    <AppShell currentPage="pricing">
+      <PageCanvas innerClassName="max-w-4xl">
+        <h1 className="font-serif text-3xl tracking-tight text-foreground sm:text-4xl">
+          Pricing
+        </h1>
+        <p className="mt-2 max-w-xl text-[15px] leading-relaxed text-muted-foreground">
+          Start free in Chat. Upgrade when you need volume, API, or team features.
+        </p>
 
-      <main className="min-h-screen bg-background">
-        {/* Hero Section */}
-        <section className="py-20 px-4">
-          <div className="max-w-4xl mx-auto text-center">
-            <h1 className="text-4xl md:text-6xl font-bold tracking-tight mb-6">
-              Simple, transparent{" "}
-              <span className="text-blue-600 dark:text-blue-400">pricing</span>
-            </h1>
-            <p className="text-xl text-muted-foreground mb-8 max-w-2xl mx-auto">
-              Start free and scale as you grow. No hidden fees, no surprises.
-            </p>
-            <div className="flex items-center justify-center gap-4 text-sm text-muted-foreground">
-              <span className="flex items-center gap-1">
-                <Check className="h-4 w-4 text-green-500" />
-                14-day free trial
-              </span>
-              <span className="flex items-center gap-1">
-                <Check className="h-4 w-4 text-green-500" />
-                Cancel anytime
-              </span>
-              <span className="flex items-center gap-1">
-                <Check className="h-4 w-4 text-green-500" />
-                No setup fees
-              </span>
-            </div>
-          </div>
-        </section>
-
-        {/* Pricing Cards */}
-        <section className="py-16 px-4">
-          <div className="max-w-6xl mx-auto">
-            <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
-              {plans.map((plan) => (
-                <Card
-                  key={plan.name}
-                  className={`relative ${plan.popular ? 'border-blue-500 shadow-lg scale-105' : 'border-muted'}`}
-                >
-                  {plan.popular && (
-                    <Badge className="absolute -top-3 left-1/2 -translate-x-1/2 bg-blue-600 text-white">
-                      Most Popular
-                    </Badge>
-                  )}
-
-                  <CardHeader className="text-center pb-4">
-                    <plan.icon className="h-8 w-8 mx-auto mb-2 text-blue-600 dark:text-blue-400" />
-                    <h3 className="text-lg font-semibold">{plan.name}</h3>
-                    <div className="mt-2">
-                      <span className="text-3xl font-bold">{plan.price}</span>
-                      {plan.period && (
-                        <span className="text-muted-foreground">/{plan.period}</span>
-                      )}
-                    </div>
-                    <p className="text-sm text-muted-foreground mt-2">{plan.description}</p>
-                  </CardHeader>
-
-                  <CardContent className="pt-0">
-                    <Button
-                      className={`w-full mb-6 ${plan.popular ? 'bg-blue-600 hover:bg-blue-700' : ''}`}
-                      variant={plan.popular ? "default" : "outline"}
-                    >
-                      {plan.cta}
-                    </Button>
-
-                    <div className="space-y-3">
-                      {plan.features.map((feature, index) => (
-                        <div key={index} className="flex items-start gap-2">
-                          <Check className="h-4 w-4 text-green-500 mt-0.5 flex-shrink-0" />
-                          <span className="text-sm">{feature}</span>
-                        </div>
-                      ))}
-
-                      {plan.limitations.map((limitation, index) => (
-                        <div key={index} className="flex items-start gap-2 opacity-60">
-                          <div className="h-4 w-4 mt-0.5 flex-shrink-0 flex items-center justify-center">
-                            <div className="h-0.5 w-2 bg-muted-foreground rounded" />
-                          </div>
-                          <span className="text-sm text-muted-foreground">{limitation}</span>
-                        </div>
-                      ))}
-                    </div>
-                  </CardContent>
-                </Card>
-              ))}
-            </div>
-          </div>
-        </section>
-
-        {/* Feature Comparison */}
-        <section className="py-16 px-4 bg-muted/30">
-          <div className="max-w-4xl mx-auto">
-            <div className="text-center mb-12">
-              <h2 className="text-3xl font-bold mb-4">Compare plans</h2>
-              <p className="text-muted-foreground">
-                See exactly what's included in each plan
+        <div className="mt-12 grid gap-4 md:grid-cols-3">
+          {plans.map((plan) => (
+            <div
+              key={plan.name}
+              className={cn(
+                'flex flex-col rounded-2xl border border-[color:var(--soft-border)] bg-card/40 p-5',
+                plan.highlighted && 'bg-card/80 ring-1 ring-foreground/10'
+              )}
+            >
+              <div className="flex items-baseline justify-between gap-2">
+                <h2 className="text-sm font-medium text-foreground">{plan.name}</h2>
+                {plan.highlighted ? (
+                  <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+                    Popular
+                  </span>
+                ) : null}
+              </div>
+              <p className="mt-3 flex items-baseline gap-1">
+                <span className="text-2xl font-semibold tracking-tight text-foreground">
+                  {plan.price}
+                </span>
+                {plan.period ? (
+                  <span className="text-xs text-muted-foreground">{plan.period}</span>
+                ) : null}
               </p>
+              <p className="mt-2 text-sm text-muted-foreground">{plan.description}</p>
+              <ul className="mt-5 flex-1 space-y-2 text-sm text-muted-foreground">
+                {plan.features.map((feature) => (
+                  <li key={feature} className="flex gap-2">
+                    <span className="mt-2 size-1 shrink-0 rounded-full bg-foreground/50" aria-hidden />
+                    {feature}
+                  </li>
+                ))}
+              </ul>
+              <Link
+                href={plan.cta.href}
+                className={cn(
+                  'mt-6 inline-flex h-10 items-center justify-center rounded-xl text-sm font-medium transition',
+                  plan.highlighted
+                    ? 'bg-foreground text-background hover:opacity-90'
+                    : 'border border-[color:var(--soft-border)] text-foreground hover:bg-muted/40'
+                )}
+              >
+                {plan.cta.label}
+              </Link>
             </div>
+          ))}
+        </div>
 
-            <div className="overflow-x-auto">
-              <table className="w-full">
-                <thead>
-                  <tr className="border-b">
-                    <th className="text-left py-4 px-4 font-medium">Feature</th>
-                    <th className="text-center py-4 px-4 font-medium">Free</th>
-                    <th className="text-center py-4 px-4 font-medium text-blue-600">Pro</th>
-                    <th className="text-center py-4 px-4 font-medium">Team</th>
-                    <th className="text-center py-4 px-4 font-medium">Enterprise</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr className="border-b border-muted">
-                    <td className="py-4 px-4">Monthly extractions</td>
-                    <td className="py-4 px-4 text-center">10</td>
-                    <td className="py-4 px-4 text-center text-blue-600">Unlimited</td>
-                    <td className="py-4 px-4 text-center">Unlimited</td>
-                    <td className="py-4 px-4 text-center">Unlimited</td>
-                  </tr>
-                  <tr className="border-b border-muted">
-                    <td className="py-4 px-4">Layout DNA analysis</td>
-                    <td className="py-4 px-4 text-center">—</td>
-                    <td className="py-4 px-4 text-center text-blue-600">✓</td>
-                    <td className="py-4 px-4 text-center">✓</td>
-                    <td className="py-4 px-4 text-center">✓</td>
-                  </tr>
-                  <tr className="border-b border-muted">
-                    <td className="py-4 px-4">API access</td>
-                    <td className="py-4 px-4 text-center">—</td>
-                    <td className="py-4 px-4 text-center text-blue-600">✓</td>
-                    <td className="py-4 px-4 text-center">✓</td>
-                    <td className="py-4 px-4 text-center">✓</td>
-                  </tr>
-                  <tr className="border-b border-muted">
-                    <td className="py-4 px-4">Team collaboration</td>
-                    <td className="py-4 px-4 text-center">—</td>
-                    <td className="py-4 px-4 text-center">—</td>
-                    <td className="py-4 px-4 text-center">✓</td>
-                    <td className="py-4 px-4 text-center">✓</td>
-                  </tr>
-                  <tr className="border-b border-muted">
-                    <td className="py-4 px-4">SSO integration</td>
-                    <td className="py-4 px-4 text-center">—</td>
-                    <td className="py-4 px-4 text-center">—</td>
-                    <td className="py-4 px-4 text-center">✓</td>
-                    <td className="py-4 px-4 text-center">✓</td>
-                  </tr>
-                  <tr className="border-b border-muted">
-                    <td className="py-4 px-4">Custom deployment</td>
-                    <td className="py-4 px-4 text-center">—</td>
-                    <td className="py-4 px-4 text-center">—</td>
-                    <td className="py-4 px-4 text-center">—</td>
-                    <td className="py-4 px-4 text-center">✓</td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </div>
-        </section>
-
-        {/* FAQ Section */}
-        <section className="py-16 px-4">
-          <div className="max-w-3xl mx-auto">
-            <div className="text-center mb-12">
-              <h2 className="text-3xl font-bold mb-4">Frequently asked questions</h2>
-              <p className="text-muted-foreground">
-                Everything you need to know about our pricing
-              </p>
-            </div>
-
-            <div className="space-y-6">
-              {faqs.map((faq, index) => (
-                <Card key={index} className="border-muted">
-                  <CardContent className="p-6">
-                    <h3 className="font-semibold mb-2">{faq.question}</h3>
-                    <p className="text-muted-foreground">{faq.answer}</p>
-                  </CardContent>
-                </Card>
-              ))}
-            </div>
-          </div>
-        </section>
-
-        {/* CTA Section */}
-        <section className="py-20 px-4 text-center">
-          <div className="max-w-2xl mx-auto">
-            <h2 className="text-3xl font-bold mb-4">Ready to get started?</h2>
-            <p className="text-muted-foreground mb-8">
-              Start with our free plan and upgrade when you need more power.
-            </p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Button className="px-8 py-3 bg-blue-600 hover:bg-blue-700">
-                Start free trial
-              </Button>
-              <Button variant="outline" className="px-8 py-3">
-                Contact sales
-              </Button>
-            </div>
-          </div>
-        </section>
-      </main>
-
-      <MarketingFooter />
-    </>
+        <p className="mt-10 text-sm text-muted-foreground">
+          Questions?{' '}
+          <Link href="/contact" className="text-foreground underline-offset-4 hover:underline">
+            Contact us
+          </Link>
+          .
+        </p>
+      </PageCanvas>
+    </AppShell>
   )
 }

--- a/app/(marketing)/privacy/page.tsx
+++ b/app/(marketing)/privacy/page.tsx
@@ -16,7 +16,7 @@ export default function PrivacyPage() {
     <AppShell currentPage="privacy">
       <PageCanvas innerClassName="max-w-3xl">
           <div className="prose prose-gray dark:prose-invert max-w-none">
-            <h1 className="font-serif text-3xl tracking-tight mb-8 sm:text-4xl">Privacy Policy</h1>
+            <h1 className="font-normal tracking-tight text-3xl tracking-tight mb-8 sm:text-4xl">Privacy Policy</h1>
             <p className="text-muted-foreground mb-8">
               Last updated: December 2024
             </p>

--- a/app/(marketing)/privacy/page.tsx
+++ b/app/(marketing)/privacy/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from "next"
-import { MarketingHeader } from "@/components/organisms/marketing-header"
-import { MarketingFooter } from "@/components/organisms/marketing-footer"
+import { AppShell } from "@/components/organisms/app-shell"
+import { PageCanvas } from "@/components/molecules/page-canvas"
 
 export const metadata: Metadata = {
   title: "Privacy Policy - designcontracts.sh",
@@ -13,13 +13,10 @@ export const metadata: Metadata = {
 
 export default function PrivacyPage() {
   return (
-    <>
-      <MarketingHeader currentPage="privacy" showSearch={true} />
-
-      <main className="min-h-screen bg-background">
-        <div className="max-w-4xl mx-auto px-4 py-20">
+    <AppShell currentPage="privacy">
+      <PageCanvas innerClassName="max-w-3xl">
           <div className="prose prose-gray dark:prose-invert max-w-none">
-            <h1 className="text-4xl font-bold tracking-tight mb-8">Privacy Policy</h1>
+            <h1 className="font-serif text-3xl tracking-tight mb-8 sm:text-4xl">Privacy Policy</h1>
             <p className="text-muted-foreground mb-8">
               Last updated: December 2024
             </p>
@@ -270,10 +267,7 @@ export default function PrivacyPage() {
               </ul>
             </section>
           </div>
-        </div>
-      </main>
-
-      <MarketingFooter />
-    </>
+      </PageCanvas>
+    </AppShell>
   )
 }

--- a/app/(marketing)/scan/client.tsx
+++ b/app/(marketing)/scan/client.tsx
@@ -111,13 +111,11 @@ function EmptyState({
 }) {
   return (
     <div className="flex flex-1 flex-col items-center justify-center px-4 pb-8 pt-16 animate-fade-in">
-      <h1 className="font-serif text-[clamp(2.5rem,7vw,3.75rem)] leading-[0.95] tracking-[-0.03em] text-foreground">
+      <h1 className="text-[clamp(2.5rem,7vw,3.75rem)] font-normal leading-[1.1] tracking-[-0.03em] text-foreground">
         designcontracts
-        <span className="font-mono text-[0.5em] tracking-normal text-[oklch(0.78_0.08_185)]">
-          .sh
-        </span>
+        <span className="font-mono text-[0.45em] tracking-normal text-primary">.sh</span>
       </h1>
-      <p className="mt-4 max-w-md text-center text-[15px] leading-relaxed text-muted-foreground">
+      <p className="mt-4 max-w-md text-center text-base font-normal leading-relaxed text-muted-foreground">
         Paste a URL. Get an installable Design Contract.
       </p>
       <div className="mt-8 flex flex-wrap items-center justify-center gap-2">
@@ -128,8 +126,8 @@ function EmptyState({
             disabled={disabled}
             onClick={() => onPick(example.prompt)}
             className={cn(
-              'rounded-full border border-[color:var(--soft-border)] bg-card/50 px-3.5 py-1.5 font-mono text-xs text-muted-foreground transition',
-              'hover:border-foreground/20 hover:bg-card hover:text-foreground disabled:opacity-50',
+              'rounded-full border border-border bg-card px-3.5 py-1.5 font-mono text-xs text-muted-foreground transition',
+              'hover:border-[var(--hairline-strong,#cfcdc4)] hover:text-foreground disabled:opacity-50',
               'animate-slide-in'
             )}
             style={{ animationDelay: `${index * 40}ms` }}
@@ -186,13 +184,13 @@ export function ScanChat() {
 
   return (
     <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
-      {/* Soft atmosphere — not a marketing hero */}
+      {/* Soft cream atmosphere — hairline-only product, no glow */}
       <div
         aria-hidden
         className="pointer-events-none absolute inset-0"
         style={{
           background:
-            'radial-gradient(720px 360px at 50% 0%, oklch(0.42 0.035 185 / 0.10), transparent 60%)',
+            'radial-gradient(720px 320px at 50% 0%, color-mix(in srgb, var(--primary) 6%, transparent), transparent 65%)',
         }}
       />
 
@@ -291,7 +289,7 @@ export function ScanChat() {
           <div className="mx-auto w-full max-w-2xl px-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] pt-1 sm:px-6">
             <PromptInput
               onSubmit={onSubmit}
-              className="rounded-2xl border-[color:var(--soft-border)] bg-card/80 shadow-[0_0_0_1px_oklch(1_0_0_/_0.03)] backdrop-blur-md"
+              className="rounded-xl border border-border bg-card"
             >
               <PromptInputBody>
                 <PromptInputTextarea

--- a/app/(marketing)/scan/client.tsx
+++ b/app/(marketing)/scan/client.tsx
@@ -111,15 +111,20 @@ function EmptyState({
   disabled?: boolean
 }) {
   return (
-    <div className="flex flex-1 flex-col items-center justify-center px-4 pb-8 pt-16 animate-fade-in">
-      <h1 className="text-[clamp(2.5rem,7vw,3.75rem)] font-normal leading-[1.1] tracking-[-0.03em] text-foreground">
+    <div className="mx-auto flex w-full max-w-[712px] flex-1 flex-col items-center justify-center px-4 pb-10 pt-14 animate-fade-in">
+      <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-[var(--ui-ink-muted)]">
+        Design Contract workbench
+      </p>
+      <h1 className="mt-3 text-[clamp(1.75rem,4vw,2.25rem)] font-semibold leading-tight tracking-[-0.02em] text-[var(--ui-ink)]">
         designcontracts
-        <span className="font-mono text-[0.45em] tracking-normal text-primary">.sh</span>
+        <span className="font-mono text-[0.5em] font-medium tracking-normal text-[var(--ui-accent)]">
+          .sh
+        </span>
       </h1>
-      <p className="mt-4 max-w-md text-center text-base font-normal leading-relaxed text-muted-foreground">
+      <p className="mt-3 max-w-md text-center text-[15px] leading-relaxed text-[var(--ui-ink-secondary)]">
         Paste a URL. Get an installable Design Contract.
       </p>
-      <div className="mt-8 flex flex-wrap items-center justify-center gap-2">
+      <div className="mt-7 flex flex-wrap items-center justify-center gap-1.5">
         {EXAMPLES.map((example, index) => (
           <button
             key={example.label}
@@ -127,8 +132,8 @@ function EmptyState({
             disabled={disabled}
             onClick={() => onPick(example.prompt)}
             className={cn(
-              'rounded-full border border-border bg-card px-3.5 py-1.5 font-mono text-xs text-muted-foreground transition',
-              'hover:border-[var(--hairline-strong,#cfcdc4)] hover:text-foreground disabled:opacity-50',
+              'h-7 rounded-[7px] bg-[var(--ui-paper)] px-2.5 font-mono text-[12px] text-[var(--ui-ink-secondary)] shadow-[var(--shadow-control)] transition',
+              'hover:bg-[var(--ui-paper-hover)] hover:text-[var(--ui-ink)] hover:shadow-[var(--shadow-control-hover)] disabled:opacity-50',
               'animate-slide-in'
             )}
             style={{ animationDelay: `${index * 40}ms` }}
@@ -185,22 +190,12 @@ export function ScanChat() {
   }
 
   return (
-    <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
-      {/* Soft cream atmosphere — hairline-only product, no glow */}
-      <div
-        aria-hidden
-        className="pointer-events-none absolute inset-0"
-        style={{
-          background:
-            'radial-gradient(720px 320px at 50% 0%, color-mix(in srgb, var(--primary) 6%, transparent), transparent 65%)',
-        }}
-      />
-
+    <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden bg-[var(--ui-paper)]">
       <div className="relative z-10 flex min-h-0 flex-1 flex-col">
         <Conversation className="min-h-0 flex-1">
           <ConversationContent
             className={cn(
-              'mx-auto w-full max-w-2xl gap-5 px-4 py-6 sm:px-6',
+              'mx-auto w-full max-w-[712px] gap-4 px-4 py-5 sm:px-6',
               !hasMessages && 'flex min-h-full flex-col'
             )}
           >
@@ -223,9 +218,9 @@ export function ScanChat() {
                 <MessageContent
                   className={cn(
                     message.role === 'user' &&
-                      'rounded-2xl bg-secondary/80 px-4 py-2.5 text-[15px] leading-relaxed',
+                      'rounded-[10px] bg-[var(--ui-paper-subtle)] px-3.5 py-2 text-[14px] leading-relaxed text-[var(--ui-ink)] shadow-[var(--shadow-control)]',
                     message.role === 'assistant' &&
-                      'w-full max-w-none gap-3 text-[15px] leading-relaxed'
+                      'w-full max-w-none gap-3 text-[14px] leading-relaxed text-[var(--ui-ink)]'
                   )}
                 >
                   {message.parts.map((part, index) => {
@@ -257,15 +252,15 @@ export function ScanChat() {
             ))}
 
             {busy && messages.at(-1)?.role === 'user' ? (
-              <div className="flex items-center gap-2 px-1 text-sm text-muted-foreground animate-fade-in">
+              <div className="flex items-center gap-2 px-1 text-[13px] text-[var(--ui-ink-secondary)] animate-fade-in">
                 <span className="inline-flex gap-1">
-                  <span className="size-1.5 animate-pulse rounded-full bg-[oklch(0.78_0.08_185)]" />
+                  <span className="size-1.5 animate-pulse rounded-full bg-[var(--ui-accent)]" />
                   <span
-                    className="size-1.5 animate-pulse rounded-full bg-[oklch(0.78_0.08_185)]"
+                    className="size-1.5 animate-pulse rounded-full bg-[var(--ui-accent)]"
                     style={{ animationDelay: '120ms' }}
                   />
                   <span
-                    className="size-1.5 animate-pulse rounded-full bg-[oklch(0.78_0.08_185)]"
+                    className="size-1.5 animate-pulse rounded-full bg-[var(--ui-accent)]"
                     style={{ animationDelay: '240ms' }}
                   />
                 </span>
@@ -274,7 +269,7 @@ export function ScanChat() {
             ) : null}
 
             {error ? (
-              <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+              <div className="rounded-[10px] border border-[var(--ui-border)] bg-[var(--ui-danger-soft)] px-3.5 py-2.5 text-[13px] text-[var(--ui-danger)]">
                 {error.message || 'Something went wrong. Try again.'}
               </div>
             ) : null}
@@ -282,16 +277,12 @@ export function ScanChat() {
           <ConversationScrollButton />
         </Conversation>
 
-        {/* Composer dock */}
-        <div className="relative shrink-0">
-          <div
-            aria-hidden
-            className="pointer-events-none absolute inset-x-0 -top-10 h-10 bg-gradient-to-t from-background to-transparent"
-          />
-          <div className="mx-auto w-full max-w-2xl px-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] pt-1 sm:px-6">
+        {/* Composer — integrated paper footer feel */}
+        <div className="relative shrink-0 border-t border-[var(--ui-border-soft)] bg-[color-mix(in_srgb,var(--ui-paper)_76%,var(--ui-paper-subtle))]">
+          <div className="mx-auto w-full max-w-[712px] px-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] pt-2 sm:px-6">
             <PromptInput
               onSubmit={onSubmit}
-              className="rounded-xl border border-border bg-card"
+              className="overflow-hidden rounded-[10px] border border-[var(--ui-border)] bg-[var(--ui-paper)] shadow-[var(--shadow-control)]"
             >
               <PromptInputBody>
                 <PromptInputTextarea
@@ -299,12 +290,12 @@ export function ScanChat() {
                   onChange={(event) => setText(event.target.value)}
                   placeholder="Ask about a site — stripe.com, linear.app…"
                   disabled={busy && status === 'submitted'}
-                  className="min-h-[52px] text-[15px] leading-relaxed placeholder:text-muted-foreground/70"
+                  className="min-h-[48px] text-[14px] leading-relaxed placeholder:text-[var(--ui-ink-muted)]"
                   aria-label="Message"
                 />
               </PromptInputBody>
-              <PromptInputFooter className="px-1">
-                <span className="truncate font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground/80">
+              <PromptInputFooter className="px-1.5">
+                <span className="truncate font-mono text-[10px] uppercase tracking-[0.14em] text-[var(--ui-ink-muted)]">
                   Design Contract
                 </span>
                 <PromptInputSubmit

--- a/app/(marketing)/scan/client.tsx
+++ b/app/(marketing)/scan/client.tsx
@@ -39,6 +39,7 @@ import {
   isScanResultToolName,
 } from '@/components/molecules/scan-result-widget'
 import type { DesignContractAgentUIMessage } from '@/lib/agent/design-contract-agent'
+import { trackClientEvent } from '@/lib/analytics/track-client'
 import { pushRecent } from '@/lib/recents'
 import { cn } from '@/lib/utils'
 
@@ -171,6 +172,7 @@ export function ScanChat() {
     const next = message.text?.trim()
     if (!next || busy) return
     setText('')
+    trackClientEvent('chat_message')
     // Best-effort: if the message looks like a bare domain, stash it in Recents.
     const maybeDomain = next
       .replace(/^https?:\/\//, '')

--- a/app/(marketing)/scan/client.tsx
+++ b/app/(marketing)/scan/client.tsx
@@ -282,7 +282,7 @@ export function ScanChat() {
           <div className="mx-auto w-full max-w-[712px] px-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] pt-2 sm:px-6">
             <PromptInput
               onSubmit={onSubmit}
-              className="overflow-hidden rounded-[10px] border border-[var(--ui-border)] bg-[var(--ui-paper)] shadow-[var(--shadow-control)]"
+              className="overflow-hidden rounded-[10px] border border-[var(--ui-border-soft)] bg-[var(--ui-paper)] shadow-[var(--shadow-control)]"
             >
               <PromptInputBody>
                 <PromptInputTextarea

--- a/app/(marketing)/site/[domain]/page.tsx
+++ b/app/(marketing)/site/[domain]/page.tsx
@@ -1,11 +1,20 @@
 'use client'
 
 import { useParams } from 'next/navigation'
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { AppShell } from '@/components/organisms/app-shell'
 import { ScanResultsLayout } from '@/components/organisms/scan-results-layout'
+import { PageCanvas } from '@/components/molecules/page-canvas'
+import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/skeleton'
 import { storedScanToClientResult } from '@/lib/scanner/scan-client-result'
+import {
+  handoffToScanResult,
+  normalizeDomain,
+  readSiteHandoff,
+} from '@/lib/site-handoff'
 import { useScanStore } from '@/stores/scan-store'
+import Link from 'next/link'
 
 type SiteApiResponse = {
   hasData?: boolean
@@ -14,10 +23,15 @@ type SiteApiResponse = {
   scan?: Parameters<typeof storedScanToClientResult>[0] | null
 }
 
+type LoadPhase = 'hydrating' | 'ready' | 'missing' | 'scanning' | 'error'
+
 export default function SitePage() {
   const params = useParams()
-  const domain = params.domain as string
+  const rawDomain = params.domain as string
+  const domain = normalizeDomain(rawDomain || '')
   const loadedFor = useRef<string | null>(null)
+  const [phase, setPhase] = useState<LoadPhase>('hydrating')
+  const [loadError, setLoadError] = useState<string | null>(null)
 
   const {
     isScanning: scanLoading,
@@ -33,19 +47,42 @@ export default function SitePage() {
   useEffect(() => {
     if (!domain || loadedFor.current === domain) return
     loadedFor.current = domain
-    void loadSite(domain)
+    void hydrateSite(domain)
     // eslint-disable-next-line react-hooks/exhaustive-deps -- load once per domain
   }, [domain])
 
-  const loadSite = async (target: string) => {
-    resetScan()
+  useEffect(() => {
+    if (scanLoading) {
+      setPhase('scanning')
+      return
+    }
+    if (scanResult?.domain === domain) {
+      setPhase('ready')
+    }
+  }, [scanLoading, scanResult, domain])
+
+  const hydrateSite = async (target: string) => {
+    setPhase('hydrating')
+    setLoadError(null)
+
+    // 1) Instant handoff from Chat Open (same tab) — never blocks on storage.
+    const handoff = readSiteHandoff(target)
+    if (handoff) {
+      const fromHandoff = handoffToScanResult(handoff)
+      if (fromHandoff) {
+        setResult(fromHandoff)
+        setPhase('ready')
+      }
+    }
+
+    // 2) Durable cache (Blob / Redis) — upgrade handoff with full pack when available.
     try {
       const response = await fetch(`/api/sites/${encodeURIComponent(target)}`)
       if (response.ok) {
         const existing = (await response.json()) as SiteApiResponse
         if (existing.hasData && existing.scan) {
-          // Already scanned (e.g. from chat widget) — show results, do not rescan.
           setResult(storedScanToClientResult(existing.scan))
+          setPhase('ready')
           return
         }
       }
@@ -53,8 +90,11 @@ export default function SitePage() {
       console.error('Error loading cached site data:', error)
     }
 
-    // No cached contract — run a quality scan via the browser scanner when configured.
-    await startScan(target, 'accurate')
+    // 3) No cache — show empty state. Do NOT auto-rescan (avoids infinite loading
+    // when scanner/env is misconfigured on preview deploys).
+    if (!handoff) {
+      setPhase('missing')
+    }
   }
 
   const handleCopyToken = (value: string) => {
@@ -94,9 +134,7 @@ export default function SitePage() {
     URL.revokeObjectURL(url)
   }
 
-  const generateCSS = (tokens: {
-    colors?: Array<{ value: string }>
-  }) => {
+  const generateCSS = (tokens: { colors?: Array<{ value: string }> }) => {
     let css = ':root {\n'
     if (tokens.colors) {
       css += '  /* Colors */\n'
@@ -113,24 +151,67 @@ export default function SitePage() {
     void navigator.clipboard.writeText(shareUrl)
   }
 
+  const runFreshScan = () => {
+    setLoadError(null)
+    resetScan()
+    setPhase('scanning')
+    void startScan(domain, 'accurate').catch((error: unknown) => {
+      setLoadError(error instanceof Error ? error.message : 'Scan failed')
+      setPhase('error')
+    })
+  }
+
   return (
     <AppShell currentPage="site" recentDomain={domain}>
-      <ScanResultsLayout
-        result={scanResult}
-        isLoading={scanLoading}
-        scanId={scanId}
-        progress={scanProgress}
-        error={scanError}
-        onCopy={handleCopyToken}
-        onExport={handleExport}
-        onShare={handleShareUrl}
-        onNewScan={() => {
-          resetScan()
-          if (domain) {
-            void startScan(domain, 'accurate')
-          }
-        }}
-      />
+      {phase === 'hydrating' && !scanResult ? (
+        <PageCanvas>
+          <div className="flex flex-col gap-6">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-10 w-64" />
+            <Skeleton className="h-4 w-full max-w-md" />
+            <div className="mt-4 grid gap-3 sm:grid-cols-3">
+              <Skeleton className="h-24 rounded-xl" />
+              <Skeleton className="h-24 rounded-xl" />
+              <Skeleton className="h-24 rounded-xl" />
+            </div>
+          </div>
+        </PageCanvas>
+      ) : null}
+
+      {phase === 'missing' && !scanResult ? (
+        <PageCanvas>
+          <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+            Contract
+          </p>
+          <h1 className="mt-2 font-serif text-3xl tracking-tight text-foreground sm:text-4xl">
+            {domain}
+          </h1>
+          <p className="mt-2 max-w-lg text-[15px] text-muted-foreground">
+            No saved Design Contract for this domain yet. Scan from Chat, or run one here.
+          </p>
+          <div className="mt-8 flex flex-wrap gap-3">
+            <Button onClick={runFreshScan}>Scan now</Button>
+            <Button variant="outline" asChild>
+              <Link href={`/?url=${encodeURIComponent(domain)}`}>Open in Chat</Link>
+            </Button>
+          </div>
+        </PageCanvas>
+      ) : null}
+
+      {(phase === 'ready' || phase === 'scanning' || phase === 'error' || scanResult) &&
+      (scanResult || scanLoading || scanError || loadError) ? (
+        <ScanResultsLayout
+          result={scanResult}
+          isLoading={scanLoading || phase === 'scanning'}
+          scanId={scanId}
+          progress={scanProgress}
+          error={scanError || loadError}
+          onCopy={handleCopyToken}
+          onExport={handleExport}
+          onShare={handleShareUrl}
+          onNewScan={runFreshScan}
+        />
+      ) : null}
     </AppShell>
   )
 }

--- a/app/(marketing)/site/[domain]/page.tsx
+++ b/app/(marketing)/site/[domain]/page.tsx
@@ -183,7 +183,7 @@ export default function SitePage() {
           <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
             Contract
           </p>
-          <h1 className="mt-2 font-serif text-3xl tracking-tight text-foreground sm:text-4xl">
+          <h1 className="mt-2 font-normal tracking-tight text-3xl tracking-tight text-foreground sm:text-4xl">
             {domain}
           </h1>
           <p className="mt-2 max-w-lg text-[15px] text-muted-foreground">

--- a/app/(marketing)/site/[domain]/page.tsx
+++ b/app/(marketing)/site/[domain]/page.tsx
@@ -8,6 +8,7 @@ import { PageCanvas } from '@/components/molecules/page-canvas'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
 import { storedScanToClientResult } from '@/lib/scanner/scan-client-result'
+import { trackClientEvent } from '@/lib/analytics/track-client'
 import {
   handoffToScanResult,
   normalizeDomain,
@@ -47,6 +48,7 @@ export default function SitePage() {
   useEffect(() => {
     if (!domain || loadedFor.current === domain) return
     loadedFor.current = domain
+    trackClientEvent('contract_open')
     void hydrateSite(domain)
     // eslint-disable-next-line react-hooks/exhaustive-deps -- load once per domain
   }, [domain])

--- a/app/(marketing)/terms/page.tsx
+++ b/app/(marketing)/terms/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from "next"
-import { MarketingHeader } from "@/components/organisms/marketing-header"
-import { MarketingFooter } from "@/components/organisms/marketing-footer"
+import { AppShell } from "@/components/organisms/app-shell"
+import { PageCanvas } from "@/components/molecules/page-canvas"
 
 export const metadata: Metadata = {
   title: "Terms of Service - designcontracts.sh",
@@ -13,13 +13,10 @@ export const metadata: Metadata = {
 
 export default function TermsPage() {
   return (
-    <>
-      <MarketingHeader currentPage="terms" showSearch={true} />
-
-      <main className="min-h-screen bg-background">
-        <div className="max-w-4xl mx-auto px-4 py-20">
+    <AppShell currentPage="terms">
+      <PageCanvas innerClassName="max-w-3xl">
           <div className="prose prose-gray dark:prose-invert max-w-none">
-            <h1 className="text-4xl font-bold tracking-tight mb-8">Terms of Service</h1>
+            <h1 className="font-serif text-3xl tracking-tight mb-8 sm:text-4xl">Terms of Service</h1>
             <p className="text-muted-foreground mb-8">
               Last updated: December 2024
             </p>
@@ -219,10 +216,7 @@ export default function TermsPage() {
               </p>
             </section>
           </div>
-        </div>
-      </main>
-
-      <MarketingFooter />
-    </>
+      </PageCanvas>
+    </AppShell>
   )
 }

--- a/app/(marketing)/terms/page.tsx
+++ b/app/(marketing)/terms/page.tsx
@@ -16,7 +16,7 @@ export default function TermsPage() {
     <AppShell currentPage="terms">
       <PageCanvas innerClassName="max-w-3xl">
           <div className="prose prose-gray dark:prose-invert max-w-none">
-            <h1 className="font-serif text-3xl tracking-tight mb-8 sm:text-4xl">Terms of Service</h1>
+            <h1 className="font-normal tracking-tight text-3xl tracking-tight mb-8 sm:text-4xl">Terms of Service</h1>
             <p className="text-muted-foreground mb-8">
               Last updated: December 2024
             </p>

--- a/app/(marketing)/ultrafast-demo/page.tsx
+++ b/app/(marketing)/ultrafast-demo/page.tsx
@@ -6,6 +6,8 @@ import { Input } from "@/components/ui/input"
 import { Badge } from "@/components/ui/badge"
 import { Progress } from "@/components/ui/progress"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { AppShell } from "@/components/organisms/app-shell"
+import { PageCanvas } from "@/components/molecules/page-canvas"
 import {
   Zap,
   Target,
@@ -166,18 +168,12 @@ export default function UltraFastDemoPage() {
   }
 
   return (
-    <div className="min-h-screen bg-background">
-      {/* Hero Section */}
-      <div className="border-b border-neutral-200 dark:border-neutral-700">
-        <div className="max-w-7xl mx-auto px-6 py-12">
-          <div className="text-center mb-8">
-            <div className="flex items-center justify-center gap-2 mb-4">
-              <Zap className="h-8 w-8 text-blue-500" />
-              <h1 className="text-4xl font-bold">Ultra-Fast Scanning Demo</h1>
-            </div>
-            <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
-              Experience scanning speeds under 200ms with our ultra-parallel system,
-              progressive loading skeletons, and optimized database operations.
+    <AppShell currentPage="metrics">
+      <PageCanvas innerClassName="max-w-6xl px-4 py-8 sm:px-6">
+          <div className="mb-8">
+            <h1 className="font-serif text-3xl tracking-tight text-foreground">Scan demo</h1>
+            <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
+              Progressive scan timing demo — same app shell as the rest of the product.
             </p>
           </div>
 
@@ -270,14 +266,10 @@ export default function UltraFastDemoPage() {
               )}
             </CardContent>
           </Card>
-        </div>
-      </div>
 
       {/* Performance Metrics */}
-      <div className="max-w-7xl mx-auto px-6 py-8">
-        <h2 className="text-2xl font-bold mb-6 flex items-center gap-2">
-          <Activity className="h-6 w-6 text-green-500" />
-          Ultra-Performance Metrics
+        <h2 className="mb-6 mt-10 font-serif text-2xl tracking-tight text-foreground">
+          Performance metrics
         </h2>
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
@@ -368,13 +360,12 @@ export default function UltraFastDemoPage() {
             </div>
           </CardContent>
         </Card>
-      </div>
 
       {/* Progressive Scan Results */}
       {(isScanning || scanResults) && (
-        <div className="border-t border-neutral-200 dark:border-neutral-700">
+        <div className="mt-8 border-t border-[color:var(--soft-border)] pt-6">
           <ProgressiveScanResults
-            scanId={currentScanId}
+            scanId={currentScanId ?? undefined}
             domain={demoUrl.replace(/^https?:\/\//, '').replace(/\/.*$/, '')}
             url={demoUrl}
             onScanComplete={handleScanComplete}
@@ -383,6 +374,7 @@ export default function UltraFastDemoPage() {
           />
         </div>
       )}
-    </div>
+      </PageCanvas>
+    </AppShell>
   )
 }

--- a/app/(marketing)/ultrafast-demo/page.tsx
+++ b/app/(marketing)/ultrafast-demo/page.tsx
@@ -171,7 +171,7 @@ export default function UltraFastDemoPage() {
     <AppShell currentPage="metrics">
       <PageCanvas innerClassName="max-w-6xl px-4 py-8 sm:px-6">
           <div className="mb-8">
-            <h1 className="font-serif text-3xl tracking-tight text-foreground">Scan demo</h1>
+            <h1 className="font-normal tracking-tight text-3xl tracking-tight text-foreground">Scan demo</h1>
             <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
               Progressive scan timing demo — same app shell as the rest of the product.
             </p>
@@ -268,7 +268,7 @@ export default function UltraFastDemoPage() {
           </Card>
 
       {/* Performance Metrics */}
-        <h2 className="mb-6 mt-10 font-serif text-2xl tracking-tight text-foreground">
+        <h2 className="mb-6 mt-10 font-normal tracking-tight text-2xl tracking-tight text-foreground">
           Performance metrics
         </h2>
 

--- a/app/api/contracts/download/route.ts
+++ b/app/api/contracts/download/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { trackStatEvent } from '@/lib/storage/platform-stats'
 import { getScan } from '@/lib/storage/serverless-store'
 import {
   buildDesignContractPackage,
@@ -83,6 +84,8 @@ export async function GET(request: NextRequest) {
 
   const zip = zipDesignContractPackage(pack)
   const fileName = `${pack.slug}-design-contract.zip`
+
+  void trackStatEvent('download')
 
   return new NextResponse(Buffer.from(zip), {
     status: 200,

--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -1,63 +1,78 @@
 import { NextResponse } from 'next/server'
-import { getScannerServiceUrl, isBrowserServiceConfigured } from '@/lib/scanner/browser-service'
 import { getDirectoryStats, getStorageBackend } from '@/lib/storage/serverless-store'
+import { getPlatformStatsSnapshot, isRedisConfigured } from '@/lib/storage/platform-stats'
 
-function scannerStatus() {
-  const url = getScannerServiceUrl()
-  let host: string | null = null
-  if (url) {
-    try {
-      host = new URL(url).host
-    } catch {
-      host = 'configured'
-    }
-  }
-  return {
-    configured: isBrowserServiceConfigured(),
-    host,
-    computedCssDisabled: process.env.DISABLE_COMPUTED_CSS === '1',
-    defaultAgentMode:
-      isBrowserServiceConfigured() && process.env.DISABLE_COMPUTED_CSS !== '1'
-        ? 'accurate'
-        : 'fast',
-  }
-}
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
 
+/**
+ * GET /api/stats
+ * Live platform stats from Redis (when configured), with Blob directory fallback.
+ */
 export async function GET() {
   try {
-    const [stats, backend] = await Promise.all([
+    const [directory, redisSnapshot] = await Promise.all([
       getDirectoryStats(),
-      Promise.resolve(getStorageBackend()),
+      getPlatformStatsSnapshot(),
     ])
 
-    return NextResponse.json(
-      {
-        ...stats,
-        storage: backend,
-        scanner: scannerStatus(),
+    const backend = getStorageBackend()
+    const redis = isRedisConfigured()
+    const mode = redis
+      ? backend.blob
+        ? 'redis+blob'
+        : 'redis'
+      : backend.blob
+        ? 'blob'
+        : 'memory'
+
+    const sites = redisSnapshot.sites > 0 ? redisSnapshot.sites : directory.sites
+    const tokens = redisSnapshot.tokens > 0 ? redisSnapshot.tokens : directory.tokens
+    const scans = redisSnapshot.scans > 0 ? redisSnapshot.scans : directory.scans
+
+    // Confidence is stored 0–1 on sites; directory average may already be percent.
+    let avgConfidence = directory.averageConfidence
+    if (avgConfidence > 1) avgConfidence = avgConfidence / 100
+
+    return NextResponse.json({
+      sites,
+      tokens,
+      avgConfidence,
+      scans,
+      cacheHits: redisSnapshot.cacheHits || directory.cacheHits,
+      cacheMisses: redisSnapshot.cacheMisses || directory.cacheMisses,
+      libraryViews: redisSnapshot.libraryViews || directory.libraryViews,
+      contractOpens: redisSnapshot.contractOpens || directory.contractOpens,
+      downloads: redisSnapshot.downloads || directory.downloads,
+      chatMessages: redisSnapshot.chatMessages || directory.chatMessages,
+      agentScans: redisSnapshot.agentScans || directory.agentScans,
+      lastUpdated: redisSnapshot.updatedAt || new Date().toISOString(),
+      storage: {
+        redis,
+        blob: backend.blob,
+        mode,
       },
-      {
-        headers: {
-          'Cache-Control': 'public, s-maxage=30, stale-while-revalidate=60',
-        },
-      }
-    )
+    })
   } catch (error) {
-    console.error('Stats error:', error)
+    console.error('Failed to get stats:', error)
     return NextResponse.json(
       {
         sites: 0,
         tokens: 0,
+        avgConfidence: 0,
         scans: 0,
-        tokenSets: 0,
-        categories: {},
-        averageConfidence: 0,
-        recentActivity: [],
-        popularSites: [],
-        storage: getStorageBackend(),
-        scanner: scannerStatus(),
+        cacheHits: 0,
+        cacheMisses: 0,
+        libraryViews: 0,
+        contractOpens: 0,
+        downloads: 0,
+        chatMessages: 0,
+        agentScans: 0,
+        lastUpdated: new Date().toISOString(),
+        storage: { redis: false, blob: false, mode: 'memory' },
+        error: 'Failed to fetch stats',
       },
-      { status: 200 }
+      { status: 500 }
     )
   }
 }

--- a/app/api/stats/track/route.ts
+++ b/app/api/stats/track/route.ts
@@ -3,13 +3,19 @@ import { isRedisConfigured, isStatEvent, trackStatEvent } from '@/lib/storage/pl
 
 export async function POST(request: NextRequest) {
   try {
-    const body = (await request.json().catch(() => null)) as { event?: unknown } | null
+    const body = (await request.json().catch(() => null)) as {
+      event?: unknown
+      by?: unknown
+    } | null
+
     if (!isStatEvent(body?.event)) {
-      return NextResponse.json(
-        { ok: false, error: 'Invalid event' },
-        { status: 400 }
-      )
+      return NextResponse.json({ ok: false, error: 'Invalid event' }, { status: 400 })
     }
+
+    const by =
+      typeof body?.by === 'number' && Number.isFinite(body.by) && body.by > 0
+        ? Math.min(Math.floor(body.by), 100)
+        : 1
 
     if (!isRedisConfigured()) {
       return NextResponse.json({
@@ -20,8 +26,8 @@ export async function POST(request: NextRequest) {
       })
     }
 
-    const tracked = await trackStatEvent(body.event)
-    return NextResponse.json({ ok: true, tracked, redis: true, event: body.event })
+    const tracked = await trackStatEvent(body.event, by)
+    return NextResponse.json({ ok: true, tracked, redis: true, event: body.event, by })
   } catch (error) {
     console.error('[stats/track]', error)
     return NextResponse.json({ ok: false, error: 'Track failed' }, { status: 500 })

--- a/app/api/stats/track/route.ts
+++ b/app/api/stats/track/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { isRedisConfigured, isStatEvent, trackStatEvent } from '@/lib/storage/platform-stats'
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = (await request.json().catch(() => null)) as { event?: unknown } | null
+    if (!isStatEvent(body?.event)) {
+      return NextResponse.json(
+        { ok: false, error: 'Invalid event' },
+        { status: 400 }
+      )
+    }
+
+    if (!isRedisConfigured()) {
+      return NextResponse.json({
+        ok: false,
+        tracked: false,
+        redis: false,
+        message: 'Redis not configured — set UPSTASH_REDIS_REST_URL + UPSTASH_REDIS_REST_TOKEN',
+      })
+    }
+
+    const tracked = await trackStatEvent(body.event)
+    return NextResponse.json({ ok: true, tracked, redis: true, event: body.event })
+  } catch (error) {
+    console.error('[stats/track]', error)
+    return NextResponse.json({ ok: false, error: 'Track failed' }, { status: 500 })
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -109,9 +109,9 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-  --font-serif: var(--font-instrument-serif), "Iowan Old Style", "Palatino Linotype", Georgia, serif;
+  --font-sans: var(--font-inter), system-ui, "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --font-mono: var(--font-jetbrains-mono), "JetBrains Mono", "Fira Code", ui-monospace, monospace;
+  --font-serif: var(--font-inter), system-ui, sans-serif;
 
   /* Enhanced semantic colors */
   --color-destructive: var(--destructive);
@@ -178,134 +178,145 @@
 }
 
 /*
- * Dark-first shadcn/ui neutral theme (ui.shadcn.com).
- * Achromatic surfaces + semantic tokens. Brand .sh accent stays mint in chrome only.
+ * Cursor-inspired cream editorial system for Design Contracts.
+ * Canvas #f7f7f4 · ink #26251e · Contract Orange #f54e00 · hairline-only depth.
  * See DESIGN.md.
  */
 :root {
-  --radius: 0.625rem;
+  --radius: 0.5rem; /* 8px CTA / input dialect */
 
-  /* Dark default (html has class="dark") — shadcn neutral */
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --destructive-foreground: oklch(0.985 0 0);
-  --warning: oklch(0.769 0.188 70.08);
-  --warning-foreground: oklch(0.205 0 0);
-  --success: oklch(0.696 0.17 162.48);
-  --success-foreground: oklch(0.145 0 0);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.985 0 0);
-  --sidebar-primary-foreground: oklch(0.205 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
-  --soft-shadow: 0 0 0 1px oklch(1 0 0 / 0.06), 0 16px 48px oklch(0 0 0 / 0.45);
-  --soft-border: oklch(1 0 0 / 10%);
-}
+  /* Cream default (light-first) */
+  --background: #f7f7f4;
+  --foreground: #26251e;
+  --card: #ffffff;
+  --card-foreground: #26251e;
+  --popover: #ffffff;
+  --popover-foreground: #26251e;
+  --primary: #f54e00;
+  --primary-foreground: #ffffff;
+  --secondary: #efeee8;
+  --secondary-foreground: #26251e;
+  --muted: #efeee8;
+  --muted-foreground: #5a5852;
+  --accent: #e6e5e0;
+  --accent-foreground: #26251e;
+  --destructive: #cf2d56;
+  --destructive-foreground: #ffffff;
+  --warning: #c08532;
+  --warning-foreground: #26251e;
+  --success: #1f8a65;
+  --success-foreground: #ffffff;
+  --border: #e6e5e0;
+  --input: #e6e5e0;
+  --ring: #f54e00;
+  --chart-1: #f54e00;
+  --chart-2: #9fc9a2;
+  --chart-3: #9fbbe0;
+  --chart-4: #c0a8dd;
+  --chart-5: #c08532;
+  --sidebar: #fafaf7;
+  --sidebar-foreground: #26251e;
+  --sidebar-primary: #f54e00;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #e6e5e0;
+  --sidebar-accent-foreground: #26251e;
+  --sidebar-border: #e6e5e0;
+  --sidebar-ring: #f54e00;
+  --soft-shadow: none;
+  --soft-border: #e6e5e0;
 
-.dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --destructive-foreground: oklch(0.985 0 0);
-  --warning: oklch(0.769 0.188 70.08);
-  --warning-foreground: oklch(0.205 0 0);
-  --success: oklch(0.696 0.17 162.48);
-  --success-foreground: oklch(0.145 0 0);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.985 0 0);
-  --sidebar-primary-foreground: oklch(0.205 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
-  --soft-shadow: 0 0 0 1px oklch(1 0 0 / 0.06), 0 16px 48px oklch(0 0 0 / 0.45);
-  --soft-border: oklch(1 0 0 / 10%);
+  /* Timeline pastels — scan/agent stages only */
+  --timeline-thinking: #dfa88f;
+  --timeline-grep: #9fc9a2;
+  --timeline-read: #9fbbe0;
+  --timeline-edit: #c0a8dd;
+  --timeline-done: #c08532;
+  --canvas-soft: #fafaf7;
+  --primary-active: #d04200;
+  --ink-muted: #807d72;
 }
 
 .light {
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --destructive-foreground: oklch(0.985 0 0);
-  --warning: oklch(0.84 0.16 84);
-  --warning-foreground: oklch(0.28 0.07 46);
-  --success: oklch(0.55 0.12 165);
-  --success-foreground: oklch(0.99 0 0);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
-  --soft-shadow: 0 0 0 1px oklch(0.145 0 0 / 0.06), 0 16px 40px oklch(0.145 0 0 / 0.08);
-  --soft-border: oklch(0.922 0 0);
+  --background: #f7f7f4;
+  --foreground: #26251e;
+  --card: #ffffff;
+  --card-foreground: #26251e;
+  --popover: #ffffff;
+  --popover-foreground: #26251e;
+  --primary: #f54e00;
+  --primary-foreground: #ffffff;
+  --secondary: #efeee8;
+  --secondary-foreground: #26251e;
+  --muted: #efeee8;
+  --muted-foreground: #5a5852;
+  --accent: #e6e5e0;
+  --accent-foreground: #26251e;
+  --destructive: #cf2d56;
+  --destructive-foreground: #ffffff;
+  --warning: #c08532;
+  --warning-foreground: #26251e;
+  --success: #1f8a65;
+  --success-foreground: #ffffff;
+  --border: #e6e5e0;
+  --input: #e6e5e0;
+  --ring: #f54e00;
+  --chart-1: #f54e00;
+  --chart-2: #9fc9a2;
+  --chart-3: #9fbbe0;
+  --chart-4: #c0a8dd;
+  --chart-5: #c08532;
+  --sidebar: #fafaf7;
+  --sidebar-foreground: #26251e;
+  --sidebar-primary: #f54e00;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #e6e5e0;
+  --sidebar-accent-foreground: #26251e;
+  --sidebar-border: #e6e5e0;
+  --sidebar-ring: #f54e00;
+  --soft-shadow: none;
+  --soft-border: #e6e5e0;
+}
+
+.dark {
+  /* Optional quiet dark — not the brand default */
+  --background: #1a1916;
+  --foreground: #f7f7f4;
+  --card: #24231f;
+  --card-foreground: #f7f7f4;
+  --popover: #24231f;
+  --popover-foreground: #f7f7f4;
+  --primary: #f54e00;
+  --primary-foreground: #ffffff;
+  --secondary: #2e2c27;
+  --secondary-foreground: #f7f7f4;
+  --muted: #2e2c27;
+  --muted-foreground: #a09c92;
+  --accent: #2e2c27;
+  --accent-foreground: #f7f7f4;
+  --destructive: #cf2d56;
+  --destructive-foreground: #ffffff;
+  --warning: #c08532;
+  --warning-foreground: #1a1916;
+  --success: #1f8a65;
+  --success-foreground: #ffffff;
+  --border: #3a3832;
+  --input: #3a3832;
+  --ring: #f54e00;
+  --chart-1: #f54e00;
+  --chart-2: #9fc9a2;
+  --chart-3: #9fbbe0;
+  --chart-4: #c0a8dd;
+  --chart-5: #c08532;
+  --sidebar: #1f1e1a;
+  --sidebar-foreground: #f7f7f4;
+  --sidebar-primary: #f54e00;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #2e2c27;
+  --sidebar-accent-foreground: #f7f7f4;
+  --sidebar-border: #3a3832;
+  --sidebar-ring: #f54e00;
+  --soft-shadow: none;
+  --soft-border: #3a3832;
 }
 
 @layer base {

--- a/app/globals.css
+++ b/app/globals.css
@@ -179,36 +179,11 @@
 
 /*
  * Warm Paper Workbench — Design Contracts
- * Cream canvas · warm-white paper · terracotta accent · Shopify-style bevels.
+ * Dark-first warm paper · soft borders · terracotta accent · bevel controls.
  * See DESIGN.md.
  */
 :root {
   --radius: 0.5rem;
-
-  /* Warm paper primitives */
-  --ui-canvas: #f3eee5;
-  --ui-paper: #fffdf8;
-  --ui-paper-subtle: #faf5ec;
-  --ui-paper-hover: #f5eee3;
-  --ui-paper-selected: #ede3d5;
-  --ui-ink: #2b2723;
-  --ui-ink-secondary: #675f57;
-  --ui-ink-muted: #766e65;
-  --ui-border-soft: rgba(67, 52, 38, 0.1);
-  --ui-border: rgba(67, 52, 38, 0.15);
-  --ui-border-edge: rgba(67, 52, 38, 0.22);
-  --ui-accent: #9b4f32;
-  --ui-accent-hover: #7a3f2a;
-  --ui-accent-soft: #f4e5db;
-  --ui-focus: #7d4936;
-  --ui-success: #356548;
-  --ui-success-soft: #e8f2e7;
-  --ui-warning: #7a5417;
-  --ui-warning-soft: #fff1d6;
-  --ui-danger: #9c3c32;
-  --ui-danger-soft: #f9e4e0;
-  --ui-info: #3e6670;
-  --ui-info-soft: #e5f0f1;
   --font-ui: var(--font-inter), Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 
   --radius-xs: 4px;
@@ -225,35 +200,166 @@
   --space-6: 24px;
   --space-8: 32px;
 
+  /* Dark-first default palette */
+  --ui-canvas: #161310;
+  --ui-paper: #1f1b16;
+  --ui-paper-subtle: #1a1612;
+  --ui-paper-hover: #29241e;
+  --ui-paper-selected: #342e26;
+  --ui-ink: #f0ebe3;
+  --ui-ink-secondary: #a89f94;
+  --ui-ink-muted: #7f766c;
+  /* Softer borders — barely-there edges */
+  --ui-border-soft: rgba(240, 235, 227, 0.05);
+  --ui-border: rgba(240, 235, 227, 0.08);
+  --ui-border-edge: rgba(240, 235, 227, 0.12);
+  --ui-accent: #c47a5a;
+  --ui-accent-hover: #d48b6c;
+  --ui-accent-soft: rgba(196, 122, 90, 0.16);
+  --ui-focus: #d4a08a;
+  --ui-success: #6fad88;
+  --ui-success-soft: rgba(111, 173, 136, 0.14);
+  --ui-warning: #d4a45a;
+  --ui-warning-soft: rgba(212, 164, 90, 0.14);
+  --ui-danger: #d4786e;
+  --ui-danger-soft: rgba(212, 120, 110, 0.14);
+  --ui-info: #7a9aa3;
+  --ui-info-soft: rgba(122, 154, 163, 0.14);
+
   --shadow-control:
+    inset 0 -1px 0 rgba(0, 0, 0, 0.4),
+    inset 0 0 0 1px rgba(240, 235, 227, 0.06),
+    inset 0 0.5px 0 1.5px rgba(255, 255, 255, 0.035),
+    0 1px 1px rgba(0, 0, 0, 0.22);
+  --shadow-control-hover:
+    inset 0 -1px 0 rgba(0, 0, 0, 0.45),
+    inset 0 0 0 1px rgba(240, 235, 227, 0.09),
+    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    0 1px 2px rgba(0, 0, 0, 0.28);
+  --shadow-control-primary:
+    inset 0 -1px 0 1px rgba(0, 0, 0, 0.45),
+    inset 0 0 0 1px rgba(196, 122, 90, 0.85),
+    inset 0 0.5px 0 1.5px rgba(255, 255, 255, 0.12),
+    0 1px 2px rgba(0, 0, 0, 0.3);
+  --shadow-paper:
+    0 1px 0 rgba(0, 0, 0, 0.18),
+    0 4px 14px -6px rgba(0, 0, 0, 0.45),
+    inset 0 0.5px 0 rgba(255, 255, 255, 0.035);
+  --shadow-paper-hover:
+    0 1px 0 rgba(0, 0, 0, 0.2),
+    0 8px 18px -8px rgba(0, 0, 0, 0.5),
+    inset 0 0.5px 0 rgba(255, 255, 255, 0.045);
+  --shadow-float:
+    0 16px 40px -12px rgba(0, 0, 0, 0.55),
+    0 4px 12px -4px rgba(0, 0, 0, 0.4),
+    inset 0 0.5px 0 rgba(255, 255, 255, 0.04);
+
+  --background: var(--ui-canvas);
+  --foreground: var(--ui-ink);
+  --card: var(--ui-paper);
+  --card-foreground: var(--ui-ink);
+  --popover: var(--ui-paper);
+  --popover-foreground: var(--ui-ink);
+  --primary: var(--ui-accent);
+  --primary-foreground: #161310;
+  --secondary: var(--ui-paper-subtle);
+  --secondary-foreground: var(--ui-ink);
+  --muted: var(--ui-paper-subtle);
+  --muted-foreground: var(--ui-ink-secondary);
+  --accent: var(--ui-accent-soft);
+  --accent-foreground: var(--ui-ink);
+  --destructive: var(--ui-danger);
+  --destructive-foreground: #161310;
+  --warning: var(--ui-warning);
+  --warning-foreground: #161310;
+  --success: var(--ui-success);
+  --success-foreground: #161310;
+  --border: var(--ui-border);
+  --input: var(--ui-border);
+  --ring: var(--ui-focus);
+  --chart-1: var(--ui-accent);
+  --chart-2: #9fc9a2;
+  --chart-3: #9fbbe0;
+  --chart-4: #c0a8dd;
+  --chart-5: var(--ui-warning);
+  --sidebar: transparent;
+  --sidebar-foreground: var(--ui-ink);
+  --sidebar-primary: var(--ui-accent);
+  --sidebar-primary-foreground: #161310;
+  --sidebar-accent: var(--ui-paper-selected);
+  --sidebar-accent-foreground: var(--ui-ink);
+  --sidebar-border: var(--ui-border-soft);
+  --sidebar-ring: var(--ui-focus);
+  --soft-shadow: var(--shadow-paper);
+  --soft-border: var(--ui-border-soft);
+
+  --timeline-thinking: #dfa88f;
+  --timeline-grep: #9fc9a2;
+  --timeline-read: #9fbbe0;
+  --timeline-edit: #c0a8dd;
+  --timeline-done: #c08532;
+  --canvas-soft: var(--ui-paper-subtle);
+  --primary-active: var(--ui-accent-hover);
+  --ink-muted: var(--ui-ink-muted);
+}
+
+.dark {
+  /* aliases :root dark-first tokens */
+}
+
+.light {
+  --ui-canvas: #f3eee5;
+  --ui-paper: #fffdf8;
+  --ui-paper-subtle: #faf5ec;
+  --ui-paper-hover: #f5eee3;
+  --ui-paper-selected: #ede3d5;
+  --ui-ink: #2b2723;
+  --ui-ink-secondary: #675f57;
+  --ui-ink-muted: #766e65;
+  --ui-border-soft: rgba(67, 52, 38, 0.055);
+  --ui-border: rgba(67, 52, 38, 0.09);
+  --ui-border-edge: rgba(67, 52, 38, 0.13);
+  --ui-accent: #9b4f32;
+  --ui-accent-hover: #7a3f2a;
+  --ui-accent-soft: #f4e5db;
+  --ui-focus: #7d4936;
+  --ui-success: #356548;
+  --ui-success-soft: #e8f2e7;
+  --ui-warning: #7a5417;
+  --ui-warning-soft: #fff1d6;
+  --ui-danger: #9c3c32;
+  --ui-danger-soft: #f9e4e0;
+  --ui-info: #3e6670;
+  --ui-info-soft: #e5f0f1;
+
+  --shadow-control:
+    inset 0 -1px 0 rgba(72, 56, 40, 0.22),
+    inset 0 0 0 1px rgba(72, 56, 40, 0.07),
+    inset 0 0.5px 0 1.5px rgba(255, 255, 255, 0.78),
+    0 1px 1px rgba(72, 56, 40, 0.04);
+  --shadow-control-hover:
     inset 0 -1px 0 rgba(72, 56, 40, 0.28),
     inset 0 0 0 1px rgba(72, 56, 40, 0.1),
-    inset 0 0.5px 0 1.5px rgba(255, 255, 255, 0.78),
-    0 1px 1px rgba(72, 56, 40, 0.05);
-  --shadow-control-hover:
-    inset 0 -1px 0 rgba(72, 56, 40, 0.34),
-    inset 0 0 0 1px rgba(72, 56, 40, 0.13),
     inset 0 1px 0 rgba(255, 255, 255, 0.88),
-    0 1px 2px rgba(72, 56, 40, 0.07);
+    0 1px 2px rgba(72, 56, 40, 0.06);
   --shadow-control-primary:
-    inset 0 -1px 0 1px rgba(65, 31, 21, 0.62),
-    inset 0 0 0 1px rgba(105, 49, 31, 0.92),
+    inset 0 -1px 0 1px rgba(65, 31, 21, 0.55),
+    inset 0 0 0 1px rgba(105, 49, 31, 0.88),
     inset 0 0.5px 0 1.5px rgba(255, 255, 255, 0.26),
-    0 1px 2px rgba(72, 35, 24, 0.16);
+    0 1px 2px rgba(72, 35, 24, 0.14);
   --shadow-paper:
-    0 1px 0 rgba(67, 52, 38, 0.07),
-    0 3px 8px -5px rgba(67, 52, 38, 0.22),
+    0 1px 0 rgba(67, 52, 38, 0.05),
+    0 3px 10px -5px rgba(67, 52, 38, 0.16),
     inset 0 0.5px 0 rgba(255, 255, 255, 0.72);
   --shadow-paper-hover:
-    0 1px 0 rgba(67, 52, 38, 0.08),
-    0 6px 14px -8px rgba(67, 52, 38, 0.28),
+    0 1px 0 rgba(67, 52, 38, 0.06),
+    0 6px 14px -8px rgba(67, 52, 38, 0.2),
     inset 0 0.5px 0 rgba(255, 255, 255, 0.78);
   --shadow-float:
-    0 16px 40px -12px rgba(52, 40, 29, 0.28),
-    0 4px 12px -4px rgba(52, 40, 29, 0.18),
+    0 16px 40px -12px rgba(52, 40, 29, 0.24),
+    0 4px 12px -4px rgba(52, 40, 29, 0.14),
     inset 0 0.5px 0 rgba(255, 255, 255, 0.75);
 
-  /* shadcn semantic map → warm paper */
   --background: var(--ui-canvas);
   --foreground: var(--ui-ink);
   --card: var(--ui-paper);
@@ -292,112 +398,6 @@
   --sidebar-ring: var(--ui-focus);
   --soft-shadow: var(--shadow-paper);
   --soft-border: var(--ui-border-soft);
-
-  --timeline-thinking: #dfa88f;
-  --timeline-grep: #9fc9a2;
-  --timeline-read: #9fbbe0;
-  --timeline-edit: #c0a8dd;
-  --timeline-done: #c08532;
-  --canvas-soft: var(--ui-paper-subtle);
-  --primary-active: var(--ui-accent-hover);
-  --ink-muted: var(--ui-ink-muted);
-}
-
-.light {
-  /* inherits :root warm paper */
-}
-
-.dark {
-  --ui-canvas: #1c1916;
-  --ui-paper: #26221d;
-  --ui-paper-subtle: #221e19;
-  --ui-paper-hover: #2e2923;
-  --ui-paper-selected: #3a332b;
-  --ui-ink: #f3eee5;
-  --ui-ink-secondary: #b4aaa0;
-  --ui-ink-muted: #8f857a;
-  --ui-border-soft: rgba(243, 238, 229, 0.08);
-  --ui-border: rgba(243, 238, 229, 0.14);
-  --ui-border-edge: rgba(243, 238, 229, 0.22);
-  --ui-accent: #c47a5a;
-  --ui-accent-hover: #d48b6c;
-  --ui-accent-soft: rgba(196, 122, 90, 0.18);
-  --ui-focus: #d4a08a;
-  --ui-success: #6fad88;
-  --ui-success-soft: rgba(111, 173, 136, 0.16);
-  --ui-warning: #d4a45a;
-  --ui-warning-soft: rgba(212, 164, 90, 0.16);
-  --ui-danger: #d4786e;
-  --ui-danger-soft: rgba(212, 120, 110, 0.16);
-  --ui-info: #7a9aa3;
-  --ui-info-soft: rgba(122, 154, 163, 0.16);
-
-  --shadow-control:
-    inset 0 -1px 0 rgba(0, 0, 0, 0.35),
-    inset 0 0 0 1px rgba(243, 238, 229, 0.08),
-    inset 0 0.5px 0 1.5px rgba(255, 255, 255, 0.04),
-    0 1px 1px rgba(0, 0, 0, 0.2);
-  --shadow-control-hover:
-    inset 0 -1px 0 rgba(0, 0, 0, 0.4),
-    inset 0 0 0 1px rgba(243, 238, 229, 0.12),
-    inset 0 1px 0 rgba(255, 255, 255, 0.06),
-    0 1px 2px rgba(0, 0, 0, 0.25);
-  --shadow-control-primary:
-    inset 0 -1px 0 1px rgba(0, 0, 0, 0.45),
-    inset 0 0 0 1px rgba(196, 122, 90, 0.9),
-    inset 0 0.5px 0 1.5px rgba(255, 255, 255, 0.12),
-    0 1px 2px rgba(0, 0, 0, 0.3);
-  --shadow-paper:
-    0 1px 0 rgba(0, 0, 0, 0.2),
-    0 3px 8px -5px rgba(0, 0, 0, 0.4),
-    inset 0 0.5px 0 rgba(255, 255, 255, 0.04);
-  --shadow-paper-hover:
-    0 1px 0 rgba(0, 0, 0, 0.22),
-    0 6px 14px -8px rgba(0, 0, 0, 0.45),
-    inset 0 0.5px 0 rgba(255, 255, 255, 0.05);
-  --shadow-float:
-    0 16px 40px -12px rgba(0, 0, 0, 0.5),
-    0 4px 12px -4px rgba(0, 0, 0, 0.35),
-    inset 0 0.5px 0 rgba(255, 255, 255, 0.05);
-
-  --background: var(--ui-canvas);
-  --foreground: var(--ui-ink);
-  --card: var(--ui-paper);
-  --card-foreground: var(--ui-ink);
-  --popover: var(--ui-paper);
-  --popover-foreground: var(--ui-ink);
-  --primary: var(--ui-accent);
-  --primary-foreground: #1c1916;
-  --secondary: var(--ui-paper-subtle);
-  --secondary-foreground: var(--ui-ink);
-  --muted: var(--ui-paper-subtle);
-  --muted-foreground: var(--ui-ink-secondary);
-  --accent: var(--ui-accent-soft);
-  --accent-foreground: var(--ui-ink);
-  --destructive: var(--ui-danger);
-  --destructive-foreground: #1c1916;
-  --warning: var(--ui-warning);
-  --warning-foreground: #1c1916;
-  --success: var(--ui-success);
-  --success-foreground: #1c1916;
-  --border: var(--ui-border);
-  --input: var(--ui-border);
-  --ring: var(--ui-focus);
-  --chart-1: var(--ui-accent);
-  --chart-2: #9fc9a2;
-  --chart-3: #9fbbe0;
-  --chart-4: #c0a8dd;
-  --chart-5: var(--ui-warning);
-  --sidebar: transparent;
-  --sidebar-foreground: var(--ui-ink);
-  --sidebar-primary: var(--ui-accent);
-  --sidebar-primary-foreground: #1c1916;
-  --sidebar-accent: var(--ui-paper-selected);
-  --sidebar-accent-foreground: var(--ui-ink);
-  --sidebar-border: var(--ui-border-soft);
-  --sidebar-ring: var(--ui-focus);
-  --soft-shadow: var(--shadow-paper);
-  --soft-border: var(--ui-border-soft);
   --canvas-soft: var(--ui-paper-subtle);
   --primary-active: var(--ui-accent-hover);
   --ink-muted: var(--ui-ink-muted);
@@ -408,14 +408,14 @@
   overflow: clip;
   background: var(--ui-paper);
   color: var(--ui-ink);
-  border: 1px solid var(--ui-border);
+  border: 1px solid var(--ui-border-soft);
   border-radius: var(--radius-paper);
   box-shadow: var(--shadow-paper);
 }
 
 .paper--shell {
   border-radius: var(--radius-shell);
-  border-color: var(--ui-border-edge);
+  border-color: var(--ui-border);
 }
 
 .paper__toolbar,

--- a/app/globals.css
+++ b/app/globals.css
@@ -160,10 +160,13 @@
   --color-sidebar-ring: var(--sidebar-ring);
 
   /* Border radius system */
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
+  --radius-sm: calc(var(--radius) * 0.6);
+  --radius-md: calc(var(--radius) * 0.8);
   --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
+  --radius-xl: calc(var(--radius) * 1.4);
+  --radius-2xl: calc(var(--radius) * 1.8);
+  --radius-3xl: calc(var(--radius) * 2.2);
+  --radius-4xl: calc(var(--radius) * 2.6);
 
   /* Scan interface colors */
   --color-scan-primary: var(--primary);
@@ -175,155 +178,134 @@
 }
 
 /*
- * Dark-first system — Vercel product density × Cursor craft.
- * Hierarchy via weight/tone (Mobbin/Vercel), hairline borders, tight radii.
- * Accent is cool mint for scan emphasis — no purple glow.
+ * Dark-first shadcn/ui neutral theme (ui.shadcn.com).
+ * Achromatic surfaces + semantic tokens. Brand .sh accent stays mint in chrome only.
+ * See DESIGN.md.
  */
 :root {
-  /* Softer app panels — see DESIGN.md */
-  --radius: 0.75rem;
+  --radius: 0.625rem;
 
-  --background: oklch(0.11 0.005 260);
-  --foreground: oklch(0.96 0.004 260);
-
-  --card: oklch(0.155 0.006 260);
-  --card-foreground: oklch(0.96 0.004 260);
-  --popover: oklch(0.155 0.006 260);
-  --popover-foreground: oklch(0.96 0.004 260);
-
-  --primary: oklch(0.97 0.003 260);
-  --primary-foreground: oklch(0.14 0.005 260);
-
-  --secondary: oklch(0.2 0.008 260);
-  --secondary-foreground: oklch(0.92 0.004 260);
-
-  --muted: oklch(0.18 0.006 260);
-  --muted-foreground: oklch(0.68 0.01 260);
-
-  --accent: oklch(0.22 0.035 185);
-  --accent-foreground: oklch(0.9 0.04 185);
-
-  --destructive: oklch(0.65 0.18 22);
-  --destructive-foreground: oklch(0.98 0.01 22);
-  --warning: oklch(0.8 0.12 85);
-  --warning-foreground: oklch(0.18 0.03 85);
-  --success: oklch(0.72 0.12 165);
-  --success-foreground: oklch(0.14 0.02 165);
-
-  --border: oklch(0.28 0.01 260);
-  --input: oklch(0.18 0.006 260);
-  --ring: oklch(0.72 0.05 185);
-
-  --chart-1: oklch(0.72 0.16 22);
-  --chart-2: oklch(0.75 0.12 185);
-  --chart-3: oklch(0.72 0.14 155);
-  --chart-4: oklch(0.8 0.12 85);
-  --chart-5: oklch(0.7 0.04 260);
-
-  --sidebar: oklch(0.11 0.005 260);
-  --sidebar-foreground: oklch(0.94 0.004 260);
-  --sidebar-primary: oklch(0.97 0.003 260);
-  --sidebar-primary-foreground: oklch(0.14 0.005 260);
-  --sidebar-accent: oklch(0.2 0.03 185);
-  --sidebar-accent-foreground: oklch(0.9 0.04 185);
-  --sidebar-border: oklch(0.26 0.01 260);
-  --sidebar-ring: oklch(0.72 0.05 185);
-
-  --soft-shadow: 0 0 0 1px oklch(1 0 0 / 0.04), 0 24px 64px oklch(0 0 0 / 0.45);
-  --soft-border: oklch(1 0 0 / 0.1);
+  /* Dark default (html has class="dark") — shadcn neutral */
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.205 0 0);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.922 0 0);
+  --primary-foreground: oklch(0.205 0 0);
+  --secondary: oklch(0.269 0 0);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  --accent: oklch(0.269 0 0);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --destructive-foreground: oklch(0.985 0 0);
+  --warning: oklch(0.769 0.188 70.08);
+  --warning-foreground: oklch(0.205 0 0);
+  --success: oklch(0.696 0.17 162.48);
+  --success-foreground: oklch(0.145 0 0);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.556 0 0);
+  --chart-1: oklch(0.488 0.243 264.376);
+  --chart-2: oklch(0.696 0.17 162.48);
+  --chart-3: oklch(0.769 0.188 70.08);
+  --chart-4: oklch(0.627 0.265 303.9);
+  --chart-5: oklch(0.645 0.246 16.439);
+  --sidebar: oklch(0.205 0 0);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.985 0 0);
+  --sidebar-primary-foreground: oklch(0.205 0 0);
+  --sidebar-accent: oklch(0.269 0 0);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-ring: oklch(0.556 0 0);
+  --soft-shadow: 0 0 0 1px oklch(1 0 0 / 0.06), 0 16px 48px oklch(0 0 0 / 0.45);
+  --soft-border: oklch(1 0 0 / 10%);
 }
 
 .dark {
-  /* Same as :root — dark is the default surface */
-  --background: oklch(0.12 0.005 260);
-  --foreground: oklch(0.96 0.004 260);
-  --card: oklch(0.155 0.006 260);
-  --card-foreground: oklch(0.96 0.004 260);
-  --popover: oklch(0.155 0.006 260);
-  --popover-foreground: oklch(0.96 0.004 260);
-  --primary: oklch(0.97 0.003 260);
-  --primary-foreground: oklch(0.14 0.005 260);
-  --secondary: oklch(0.2 0.008 260);
-  --secondary-foreground: oklch(0.92 0.004 260);
-  --muted: oklch(0.18 0.006 260);
-  --muted-foreground: oklch(0.68 0.01 260);
-  --accent: oklch(0.22 0.035 185);
-  --accent-foreground: oklch(0.9 0.04 185);
-  --destructive: oklch(0.65 0.18 22);
-  --destructive-foreground: oklch(0.98 0.01 22);
-  --warning: oklch(0.8 0.12 85);
-  --warning-foreground: oklch(0.18 0.03 85);
-  --success: oklch(0.72 0.12 165);
-  --success-foreground: oklch(0.14 0.02 165);
-  --border: oklch(0.28 0.01 260);
-  --input: oklch(0.18 0.006 260);
-  --ring: oklch(0.72 0.05 185);
-  --chart-1: oklch(0.72 0.16 22);
-  --chart-2: oklch(0.75 0.12 185);
-  --chart-3: oklch(0.72 0.14 155);
-  --chart-4: oklch(0.8 0.12 85);
-  --chart-5: oklch(0.7 0.04 260);
-  --sidebar: oklch(0.11 0.005 260);
-  --sidebar-foreground: oklch(0.94 0.004 260);
-  --sidebar-primary: oklch(0.97 0.003 260);
-  --sidebar-primary-foreground: oklch(0.14 0.005 260);
-  --sidebar-accent: oklch(0.2 0.03 185);
-  --sidebar-accent-foreground: oklch(0.9 0.04 185);
-  --sidebar-border: oklch(0.26 0.01 260);
-  --sidebar-ring: oklch(0.72 0.05 185);
-  --soft-shadow: 0 0 0 1px oklch(1 0 0 / 0.04), 0 24px 64px oklch(0 0 0 / 0.45);
-  --soft-border: oklch(1 0 0 / 0.1);
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.205 0 0);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.922 0 0);
+  --primary-foreground: oklch(0.205 0 0);
+  --secondary: oklch(0.269 0 0);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  --accent: oklch(0.269 0 0);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --destructive-foreground: oklch(0.985 0 0);
+  --warning: oklch(0.769 0.188 70.08);
+  --warning-foreground: oklch(0.205 0 0);
+  --success: oklch(0.696 0.17 162.48);
+  --success-foreground: oklch(0.145 0 0);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.556 0 0);
+  --chart-1: oklch(0.488 0.243 264.376);
+  --chart-2: oklch(0.696 0.17 162.48);
+  --chart-3: oklch(0.769 0.188 70.08);
+  --chart-4: oklch(0.627 0.265 303.9);
+  --chart-5: oklch(0.645 0.246 16.439);
+  --sidebar: oklch(0.205 0 0);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.985 0 0);
+  --sidebar-primary-foreground: oklch(0.205 0 0);
+  --sidebar-accent: oklch(0.269 0 0);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-ring: oklch(0.556 0 0);
+  --soft-shadow: 0 0 0 1px oklch(1 0 0 / 0.06), 0 16px 48px oklch(0 0 0 / 0.45);
+  --soft-border: oklch(1 0 0 / 10%);
 }
 
 .light {
-  --background: oklch(0.985 0.004 260);
-  --foreground: oklch(0.18 0.01 260);
-
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
-  --card-foreground: oklch(0.18 0.01 260);
+  --card-foreground: oklch(0.145 0 0);
   --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.18 0.01 260);
-
-  --primary: oklch(0.18 0.01 260);
-  --primary-foreground: oklch(0.99 0.002 260);
-
-  --secondary: oklch(0.96 0.006 260);
-  --secondary-foreground: oklch(0.28 0.01 260);
-
-  --muted: oklch(0.955 0.005 260);
-  --muted-foreground: oklch(0.48 0.015 260);
-
-  --accent: oklch(0.94 0.025 185);
-  --accent-foreground: oklch(0.28 0.04 185);
-
-  --destructive: oklch(0.58 0.2 22);
-  --destructive-foreground: oklch(0.99 0.005 22);
-  --warning: oklch(0.78 0.12 85);
-  --warning-foreground: oklch(0.28 0.04 85);
+  --popover-foreground: oklch(0.145 0 0);
+  --primary: oklch(0.205 0 0);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.97 0 0);
+  --secondary-foreground: oklch(0.205 0 0);
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --accent: oklch(0.97 0 0);
+  --accent-foreground: oklch(0.205 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  --destructive-foreground: oklch(0.985 0 0);
+  --warning: oklch(0.84 0.16 84);
+  --warning-foreground: oklch(0.28 0.07 46);
   --success: oklch(0.55 0.12 165);
-  --success-foreground: oklch(0.99 0.005 165);
-
-  --border: oklch(0.9 0.008 260);
-  --input: oklch(0.94 0.005 260);
-  --ring: oklch(0.45 0.05 185);
-
-  --chart-1: oklch(0.58 0.16 22);
-  --chart-2: oklch(0.55 0.1 185);
-  --chart-3: oklch(0.55 0.12 155);
-  --chart-4: oklch(0.72 0.1 85);
-  --chart-5: oklch(0.4 0.03 260);
-
-  --sidebar: oklch(0.975 0.004 260);
-  --sidebar-foreground: oklch(0.2 0.01 260);
-  --sidebar-primary: oklch(0.18 0.01 260);
-  --sidebar-primary-foreground: oklch(0.99 0.002 260);
-  --sidebar-accent: oklch(0.94 0.025 185);
-  --sidebar-accent-foreground: oklch(0.28 0.04 185);
-  --sidebar-border: oklch(0.9 0.008 260);
-  --sidebar-ring: oklch(0.45 0.05 185);
-
-  --soft-shadow: 0 0 0 1px oklch(0.2 0.01 260 / 0.06), 0 16px 40px oklch(0.2 0.01 260 / 0.08);
-  --soft-border: oklch(0.2 0.01 260 / 0.12);
+  --success-foreground: oklch(0.99 0 0);
+  --border: oklch(0.922 0 0);
+  --input: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+  --chart-1: oklch(0.646 0.222 41.116);
+  --chart-2: oklch(0.6 0.118 184.704);
+  --chart-3: oklch(0.398 0.07 227.392);
+  --chart-4: oklch(0.828 0.189 84.429);
+  --chart-5: oklch(0.769 0.188 70.08);
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.145 0 0);
+  --sidebar-primary: oklch(0.205 0 0);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.97 0 0);
+  --sidebar-accent-foreground: oklch(0.205 0 0);
+  --sidebar-border: oklch(0.922 0 0);
+  --sidebar-ring: oklch(0.708 0 0);
+  --soft-shadow: 0 0 0 1px oklch(0.145 0 0 / 0.06), 0 16px 40px oklch(0.145 0 0 / 0.08);
+  --soft-border: oklch(0.922 0 0);
 }
 
 @layer base {
@@ -339,8 +321,7 @@
 
   /* Enhanced focus management for accessibility */
   :focus-visible {
-    @apply outline-2 outline-offset-2;
-    outline-color: oklch(0.72 0.05 185);
+    @apply outline-2 outline-offset-2 outline-ring;
   }
 
   /* High contrast mode support */

--- a/app/globals.css
+++ b/app/globals.css
@@ -178,145 +178,300 @@
 }
 
 /*
- * Cursor-inspired cream editorial system for Design Contracts.
- * Canvas #f7f7f4 · ink #26251e · Contract Orange #f54e00 · hairline-only depth.
+ * Warm Paper Workbench — Design Contracts
+ * Cream canvas · warm-white paper · terracotta accent · Shopify-style bevels.
  * See DESIGN.md.
  */
 :root {
-  --radius: 0.5rem; /* 8px CTA / input dialect */
+  --radius: 0.5rem;
 
-  /* Cream default (light-first) */
-  --background: #f7f7f4;
-  --foreground: #26251e;
-  --card: #ffffff;
-  --card-foreground: #26251e;
-  --popover: #ffffff;
-  --popover-foreground: #26251e;
-  --primary: #f54e00;
-  --primary-foreground: #ffffff;
-  --secondary: #efeee8;
-  --secondary-foreground: #26251e;
-  --muted: #efeee8;
-  --muted-foreground: #5a5852;
-  --accent: #e6e5e0;
-  --accent-foreground: #26251e;
-  --destructive: #cf2d56;
-  --destructive-foreground: #ffffff;
-  --warning: #c08532;
-  --warning-foreground: #26251e;
-  --success: #1f8a65;
-  --success-foreground: #ffffff;
-  --border: #e6e5e0;
-  --input: #e6e5e0;
-  --ring: #f54e00;
-  --chart-1: #f54e00;
+  /* Warm paper primitives */
+  --ui-canvas: #f3eee5;
+  --ui-paper: #fffdf8;
+  --ui-paper-subtle: #faf5ec;
+  --ui-paper-hover: #f5eee3;
+  --ui-paper-selected: #ede3d5;
+  --ui-ink: #2b2723;
+  --ui-ink-secondary: #675f57;
+  --ui-ink-muted: #766e65;
+  --ui-border-soft: rgba(67, 52, 38, 0.1);
+  --ui-border: rgba(67, 52, 38, 0.15);
+  --ui-border-edge: rgba(67, 52, 38, 0.22);
+  --ui-accent: #9b4f32;
+  --ui-accent-hover: #7a3f2a;
+  --ui-accent-soft: #f4e5db;
+  --ui-focus: #7d4936;
+  --ui-success: #356548;
+  --ui-success-soft: #e8f2e7;
+  --ui-warning: #7a5417;
+  --ui-warning-soft: #fff1d6;
+  --ui-danger: #9c3c32;
+  --ui-danger-soft: #f9e4e0;
+  --ui-info: #3e6670;
+  --ui-info-soft: #e5f0f1;
+  --font-ui: var(--font-inter), Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+
+  --radius-xs: 4px;
+  --radius-sm: 6px;
+  --radius-md: 8px;
+  --radius-paper: 10px;
+  --radius-shell: 12px;
+  --radius-full: 9999px;
+
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-6: 24px;
+  --space-8: 32px;
+
+  --shadow-control:
+    inset 0 -1px 0 rgba(72, 56, 40, 0.28),
+    inset 0 0 0 1px rgba(72, 56, 40, 0.1),
+    inset 0 0.5px 0 1.5px rgba(255, 255, 255, 0.78),
+    0 1px 1px rgba(72, 56, 40, 0.05);
+  --shadow-control-hover:
+    inset 0 -1px 0 rgba(72, 56, 40, 0.34),
+    inset 0 0 0 1px rgba(72, 56, 40, 0.13),
+    inset 0 1px 0 rgba(255, 255, 255, 0.88),
+    0 1px 2px rgba(72, 56, 40, 0.07);
+  --shadow-control-primary:
+    inset 0 -1px 0 1px rgba(65, 31, 21, 0.62),
+    inset 0 0 0 1px rgba(105, 49, 31, 0.92),
+    inset 0 0.5px 0 1.5px rgba(255, 255, 255, 0.26),
+    0 1px 2px rgba(72, 35, 24, 0.16);
+  --shadow-paper:
+    0 1px 0 rgba(67, 52, 38, 0.07),
+    0 3px 8px -5px rgba(67, 52, 38, 0.22),
+    inset 0 0.5px 0 rgba(255, 255, 255, 0.72);
+  --shadow-paper-hover:
+    0 1px 0 rgba(67, 52, 38, 0.08),
+    0 6px 14px -8px rgba(67, 52, 38, 0.28),
+    inset 0 0.5px 0 rgba(255, 255, 255, 0.78);
+  --shadow-float:
+    0 16px 40px -12px rgba(52, 40, 29, 0.28),
+    0 4px 12px -4px rgba(52, 40, 29, 0.18),
+    inset 0 0.5px 0 rgba(255, 255, 255, 0.75);
+
+  /* shadcn semantic map → warm paper */
+  --background: var(--ui-canvas);
+  --foreground: var(--ui-ink);
+  --card: var(--ui-paper);
+  --card-foreground: var(--ui-ink);
+  --popover: var(--ui-paper);
+  --popover-foreground: var(--ui-ink);
+  --primary: var(--ui-accent);
+  --primary-foreground: var(--ui-paper);
+  --secondary: var(--ui-paper-subtle);
+  --secondary-foreground: var(--ui-ink);
+  --muted: var(--ui-paper-subtle);
+  --muted-foreground: var(--ui-ink-secondary);
+  --accent: var(--ui-accent-soft);
+  --accent-foreground: var(--ui-ink);
+  --destructive: var(--ui-danger);
+  --destructive-foreground: var(--ui-paper);
+  --warning: var(--ui-warning);
+  --warning-foreground: var(--ui-ink);
+  --success: var(--ui-success);
+  --success-foreground: var(--ui-paper);
+  --border: var(--ui-border);
+  --input: var(--ui-border);
+  --ring: var(--ui-focus);
+  --chart-1: var(--ui-accent);
   --chart-2: #9fc9a2;
   --chart-3: #9fbbe0;
   --chart-4: #c0a8dd;
-  --chart-5: #c08532;
-  --sidebar: #fafaf7;
-  --sidebar-foreground: #26251e;
-  --sidebar-primary: #f54e00;
-  --sidebar-primary-foreground: #ffffff;
-  --sidebar-accent: #e6e5e0;
-  --sidebar-accent-foreground: #26251e;
-  --sidebar-border: #e6e5e0;
-  --sidebar-ring: #f54e00;
-  --soft-shadow: none;
-  --soft-border: #e6e5e0;
+  --chart-5: var(--ui-warning);
+  --sidebar: transparent;
+  --sidebar-foreground: var(--ui-ink);
+  --sidebar-primary: var(--ui-accent);
+  --sidebar-primary-foreground: var(--ui-paper);
+  --sidebar-accent: var(--ui-paper-selected);
+  --sidebar-accent-foreground: var(--ui-ink);
+  --sidebar-border: var(--ui-border-soft);
+  --sidebar-ring: var(--ui-focus);
+  --soft-shadow: var(--shadow-paper);
+  --soft-border: var(--ui-border-soft);
 
-  /* Timeline pastels — scan/agent stages only */
   --timeline-thinking: #dfa88f;
   --timeline-grep: #9fc9a2;
   --timeline-read: #9fbbe0;
   --timeline-edit: #c0a8dd;
   --timeline-done: #c08532;
-  --canvas-soft: #fafaf7;
-  --primary-active: #d04200;
-  --ink-muted: #807d72;
+  --canvas-soft: var(--ui-paper-subtle);
+  --primary-active: var(--ui-accent-hover);
+  --ink-muted: var(--ui-ink-muted);
 }
 
 .light {
-  --background: #f7f7f4;
-  --foreground: #26251e;
-  --card: #ffffff;
-  --card-foreground: #26251e;
-  --popover: #ffffff;
-  --popover-foreground: #26251e;
-  --primary: #f54e00;
-  --primary-foreground: #ffffff;
-  --secondary: #efeee8;
-  --secondary-foreground: #26251e;
-  --muted: #efeee8;
-  --muted-foreground: #5a5852;
-  --accent: #e6e5e0;
-  --accent-foreground: #26251e;
-  --destructive: #cf2d56;
-  --destructive-foreground: #ffffff;
-  --warning: #c08532;
-  --warning-foreground: #26251e;
-  --success: #1f8a65;
-  --success-foreground: #ffffff;
-  --border: #e6e5e0;
-  --input: #e6e5e0;
-  --ring: #f54e00;
-  --chart-1: #f54e00;
-  --chart-2: #9fc9a2;
-  --chart-3: #9fbbe0;
-  --chart-4: #c0a8dd;
-  --chart-5: #c08532;
-  --sidebar: #fafaf7;
-  --sidebar-foreground: #26251e;
-  --sidebar-primary: #f54e00;
-  --sidebar-primary-foreground: #ffffff;
-  --sidebar-accent: #e6e5e0;
-  --sidebar-accent-foreground: #26251e;
-  --sidebar-border: #e6e5e0;
-  --sidebar-ring: #f54e00;
-  --soft-shadow: none;
-  --soft-border: #e6e5e0;
+  /* inherits :root warm paper */
 }
 
 .dark {
-  /* Optional quiet dark — not the brand default */
-  --background: #1a1916;
-  --foreground: #f7f7f4;
-  --card: #24231f;
-  --card-foreground: #f7f7f4;
-  --popover: #24231f;
-  --popover-foreground: #f7f7f4;
-  --primary: #f54e00;
-  --primary-foreground: #ffffff;
-  --secondary: #2e2c27;
-  --secondary-foreground: #f7f7f4;
-  --muted: #2e2c27;
-  --muted-foreground: #a09c92;
-  --accent: #2e2c27;
-  --accent-foreground: #f7f7f4;
-  --destructive: #cf2d56;
-  --destructive-foreground: #ffffff;
-  --warning: #c08532;
-  --warning-foreground: #1a1916;
-  --success: #1f8a65;
-  --success-foreground: #ffffff;
-  --border: #3a3832;
-  --input: #3a3832;
-  --ring: #f54e00;
-  --chart-1: #f54e00;
+  --ui-canvas: #1c1916;
+  --ui-paper: #26221d;
+  --ui-paper-subtle: #221e19;
+  --ui-paper-hover: #2e2923;
+  --ui-paper-selected: #3a332b;
+  --ui-ink: #f3eee5;
+  --ui-ink-secondary: #b4aaa0;
+  --ui-ink-muted: #8f857a;
+  --ui-border-soft: rgba(243, 238, 229, 0.08);
+  --ui-border: rgba(243, 238, 229, 0.14);
+  --ui-border-edge: rgba(243, 238, 229, 0.22);
+  --ui-accent: #c47a5a;
+  --ui-accent-hover: #d48b6c;
+  --ui-accent-soft: rgba(196, 122, 90, 0.18);
+  --ui-focus: #d4a08a;
+  --ui-success: #6fad88;
+  --ui-success-soft: rgba(111, 173, 136, 0.16);
+  --ui-warning: #d4a45a;
+  --ui-warning-soft: rgba(212, 164, 90, 0.16);
+  --ui-danger: #d4786e;
+  --ui-danger-soft: rgba(212, 120, 110, 0.16);
+  --ui-info: #7a9aa3;
+  --ui-info-soft: rgba(122, 154, 163, 0.16);
+
+  --shadow-control:
+    inset 0 -1px 0 rgba(0, 0, 0, 0.35),
+    inset 0 0 0 1px rgba(243, 238, 229, 0.08),
+    inset 0 0.5px 0 1.5px rgba(255, 255, 255, 0.04),
+    0 1px 1px rgba(0, 0, 0, 0.2);
+  --shadow-control-hover:
+    inset 0 -1px 0 rgba(0, 0, 0, 0.4),
+    inset 0 0 0 1px rgba(243, 238, 229, 0.12),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06),
+    0 1px 2px rgba(0, 0, 0, 0.25);
+  --shadow-control-primary:
+    inset 0 -1px 0 1px rgba(0, 0, 0, 0.45),
+    inset 0 0 0 1px rgba(196, 122, 90, 0.9),
+    inset 0 0.5px 0 1.5px rgba(255, 255, 255, 0.12),
+    0 1px 2px rgba(0, 0, 0, 0.3);
+  --shadow-paper:
+    0 1px 0 rgba(0, 0, 0, 0.2),
+    0 3px 8px -5px rgba(0, 0, 0, 0.4),
+    inset 0 0.5px 0 rgba(255, 255, 255, 0.04);
+  --shadow-paper-hover:
+    0 1px 0 rgba(0, 0, 0, 0.22),
+    0 6px 14px -8px rgba(0, 0, 0, 0.45),
+    inset 0 0.5px 0 rgba(255, 255, 255, 0.05);
+  --shadow-float:
+    0 16px 40px -12px rgba(0, 0, 0, 0.5),
+    0 4px 12px -4px rgba(0, 0, 0, 0.35),
+    inset 0 0.5px 0 rgba(255, 255, 255, 0.05);
+
+  --background: var(--ui-canvas);
+  --foreground: var(--ui-ink);
+  --card: var(--ui-paper);
+  --card-foreground: var(--ui-ink);
+  --popover: var(--ui-paper);
+  --popover-foreground: var(--ui-ink);
+  --primary: var(--ui-accent);
+  --primary-foreground: #1c1916;
+  --secondary: var(--ui-paper-subtle);
+  --secondary-foreground: var(--ui-ink);
+  --muted: var(--ui-paper-subtle);
+  --muted-foreground: var(--ui-ink-secondary);
+  --accent: var(--ui-accent-soft);
+  --accent-foreground: var(--ui-ink);
+  --destructive: var(--ui-danger);
+  --destructive-foreground: #1c1916;
+  --warning: var(--ui-warning);
+  --warning-foreground: #1c1916;
+  --success: var(--ui-success);
+  --success-foreground: #1c1916;
+  --border: var(--ui-border);
+  --input: var(--ui-border);
+  --ring: var(--ui-focus);
+  --chart-1: var(--ui-accent);
   --chart-2: #9fc9a2;
   --chart-3: #9fbbe0;
   --chart-4: #c0a8dd;
-  --chart-5: #c08532;
-  --sidebar: #1f1e1a;
-  --sidebar-foreground: #f7f7f4;
-  --sidebar-primary: #f54e00;
-  --sidebar-primary-foreground: #ffffff;
-  --sidebar-accent: #2e2c27;
-  --sidebar-accent-foreground: #f7f7f4;
-  --sidebar-border: #3a3832;
-  --sidebar-ring: #f54e00;
-  --soft-shadow: none;
-  --soft-border: #3a3832;
+  --chart-5: var(--ui-warning);
+  --sidebar: transparent;
+  --sidebar-foreground: var(--ui-ink);
+  --sidebar-primary: var(--ui-accent);
+  --sidebar-primary-foreground: #1c1916;
+  --sidebar-accent: var(--ui-paper-selected);
+  --sidebar-accent-foreground: var(--ui-ink);
+  --sidebar-border: var(--ui-border-soft);
+  --sidebar-ring: var(--ui-focus);
+  --soft-shadow: var(--shadow-paper);
+  --soft-border: var(--ui-border-soft);
+  --canvas-soft: var(--ui-paper-subtle);
+  --primary-active: var(--ui-accent-hover);
+  --ink-muted: var(--ui-ink-muted);
+}
+
+/* Integrated paper containers + workbench helpers */
+.paper {
+  overflow: clip;
+  background: var(--ui-paper);
+  color: var(--ui-ink);
+  border: 1px solid var(--ui-border);
+  border-radius: var(--radius-paper);
+  box-shadow: var(--shadow-paper);
+}
+
+.paper--shell {
+  border-radius: var(--radius-shell);
+  border-color: var(--ui-border-edge);
+}
+
+.paper__toolbar,
+.paper__footer {
+  min-height: 36px;
+  padding: 6px 8px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: color-mix(in srgb, var(--ui-paper) 76%, var(--ui-paper-subtle));
+}
+
+.paper__toolbar {
+  border-bottom: 1px solid var(--ui-border-soft);
+}
+
+.paper__body {
+  min-width: 0;
+  padding: 16px;
+}
+
+.paper__footer {
+  border-top: 1px solid var(--ui-border-soft);
+}
+
+.ui-control {
+  box-shadow: var(--shadow-control);
+  background: var(--ui-paper);
+  border-radius: 7px;
+  transition: background-color 120ms ease, box-shadow 120ms ease, transform 120ms ease;
+}
+
+.ui-control:hover {
+  background: var(--ui-paper-hover);
+  box-shadow: var(--shadow-control-hover);
+}
+
+.ui-control:active {
+  transform: translateY(1px);
+  box-shadow:
+    inset 0 2px 2px rgba(72, 56, 40, 0.16),
+    inset 0 0 0 1px rgba(72, 56, 40, 0.14);
+}
+
+.ui-control-primary {
+  box-shadow: var(--shadow-control-primary);
+  background: var(--ui-accent);
+  color: var(--ui-paper);
+}
+
+.ui-control-primary:hover {
+  background: var(--ui-accent-hover);
+}
+
+.font-tabular {
+  font-variant-numeric: tabular-nums;
 }
 
 @layer base {
@@ -326,6 +481,7 @@
 
   body {
     @apply bg-background text-foreground antialiased;
+    font-family: var(--font-ui);
     font-feature-settings: 'cv02', 'cv03', 'cv04', 'cv11';
     font-optical-sizing: auto;
   }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono, Instrument_Serif } from "next/font/google";
+import { Inter, JetBrains_Mono } from "next/font/google";
 import { SkipLinks } from "@/components/atoms/skip-links";
 import { ErrorBoundary } from "@/components/atoms/error-boundary";
 import { WebVitalsReporter } from "@/components/atoms/web-vitals-reporter";
@@ -11,28 +11,21 @@ import { generateOrganizationSchema, generateWebsiteSchema, generateSoftwareAppl
 import { RESOURCE_HINTS } from "@/lib/seo/performance";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-  display: "swap", // Non-blocking font loading
-  preload: true,   // Preload critical font
-  fallback: ['system-ui', 'arial'] // Add fallback fonts
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+/** CursorGothic substitute — Inter @ 400 with tight tracking for display */
+const inter = Inter({
+  variable: "--font-inter",
   subsets: ["latin"],
   display: "swap",
-  preload: false,  // Don't preload monospace (used less)
-  fallback: ['ui-monospace', 'Menlo', 'Monaco', 'Consolas', 'monospace']
+  preload: true,
+  fallback: ["system-ui", "Helvetica Neue", "Helvetica", "Arial", "sans-serif"],
 });
 
-const instrumentSerif = Instrument_Serif({
-  variable: "--font-instrument-serif",
+const jetbrainsMono = JetBrains_Mono({
+  variable: "--font-jetbrains-mono",
   subsets: ["latin"],
-  weight: "400",
   display: "swap",
   preload: false,
+  fallback: ["Fira Code", "ui-monospace", "Menlo", "Monaco", "Consolas", "monospace"],
 });
 
 export const metadata: Metadata = {
@@ -53,7 +46,7 @@ export default function RootLayout({
   const softwareApplicationSchema = generateSoftwareApplicationSchema();
 
   return (
-    <html lang="en" className="dark" suppressHydrationWarning>
+    <html lang="en" className="light" suppressHydrationWarning>
       <head>
         {/* SEO Meta Tags */}
         <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
@@ -92,10 +85,10 @@ export default function RootLayout({
         <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
         <link rel="manifest" href="/site.webmanifest" />
 
-        {/* Dark-first brand theme colors */}
-        <meta name="theme-color" content="#141418" />
-        <meta name="theme-color" content="#141418" media="(prefers-color-scheme: dark)" />
-        <meta name="theme-color" content="#F7F7F8" media="(prefers-color-scheme: light)" />
+        {/* Cream-first brand theme colors (Cursor editorial) */}
+        <meta name="theme-color" content="#f7f7f4" />
+        <meta name="theme-color" content="#f7f7f4" media="(prefers-color-scheme: light)" />
+        <meta name="theme-color" content="#1a1916" media="(prefers-color-scheme: dark)" />
 
         {/* Structured Data - JSON-LD */}
         <script
@@ -136,10 +129,10 @@ export default function RootLayout({
                 }
 
                 try {
-                  const stored = localStorage.getItem('theme') || 'dark';
+                  const stored = localStorage.getItem('theme') || 'light';
                   setTheme(stored);
                 } catch (e) {
-                  setTheme('dark');
+                  setTheme('light');
                 }
 
                 // Performance optimizations
@@ -176,7 +169,7 @@ export default function RootLayout({
         />
       </head>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} ${instrumentSerif.variable} antialiased`}
+        className={`${inter.variable} ${jetbrainsMono.variable} font-sans antialiased`}
         suppressHydrationWarning
       >
         <SkipLinks />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -46,7 +46,7 @@ export default function RootLayout({
   const softwareApplicationSchema = generateSoftwareApplicationSchema();
 
   return (
-    <html lang="en" className="light" suppressHydrationWarning>
+    <html lang="en" className="dark" suppressHydrationWarning>
       <head>
         {/* SEO Meta Tags */}
         <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
@@ -85,10 +85,10 @@ export default function RootLayout({
         <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
         <link rel="manifest" href="/site.webmanifest" />
 
-        {/* Cream-first brand theme colors (Cursor editorial) */}
-        <meta name="theme-color" content="#f7f7f4" />
-        <meta name="theme-color" content="#f7f7f4" media="(prefers-color-scheme: light)" />
-        <meta name="theme-color" content="#1a1916" media="(prefers-color-scheme: dark)" />
+        {/* Dark-first warm paper theme colors */}
+        <meta name="theme-color" content="#161310" />
+        <meta name="theme-color" content="#161310" media="(prefers-color-scheme: dark)" />
+        <meta name="theme-color" content="#f3eee5" media="(prefers-color-scheme: light)" />
 
         {/* Structured Data - JSON-LD */}
         <script
@@ -129,10 +129,10 @@ export default function RootLayout({
                 }
 
                 try {
-                  const stored = localStorage.getItem('theme') || 'light';
+                  const stored = localStorage.getItem('theme') || 'dark';
                   setTheme(stored);
                 } catch (e) {
-                  setTheme('light');
+                  setTheme('dark');
                 }
 
                 // Performance optimizations

--- a/components/atoms/animated-counter.tsx
+++ b/components/atoms/animated-counter.tsx
@@ -1,68 +1,127 @@
-"use client"
+'use client'
 
-import { useEffect, useState, useRef } from "react"
-import { cn } from "@/lib/utils"
+import { useEffect, useRef, useState } from 'react'
+import { cn } from '@/lib/utils'
 
 interface AnimatedCounterProps {
   value: number
   className?: string
   formatCompact?: boolean
+  /** Optional suffix after the number (e.g. "%") */
+  suffix?: string
+  /** Placeholder when value is empty / zero and showZero is false */
+  emptyLabel?: string
+  showZero?: boolean
+  durationMs?: number
 }
 
-export function AnimatedCounter({ value, className, formatCompact = false }: AnimatedCounterProps) {
-  const [displayValue, setDisplayValue] = useState(value)
-  const [isAnimating, setIsAnimating] = useState(false)
-  const prevValueRef = useRef(value)
+function formatCompactNumber(num: number): string {
+  if (!Number.isFinite(num) || num < 0) return '0'
+  if (num >= 1_000_000) return `${(num / 1_000_000).toFixed(1).replace(/\.0$/, '')}M`
+  if (num >= 1_000) return `${(num / 1_000).toFixed(1).replace(/\.0$/, '')}k`
+  return String(Math.round(num))
+}
 
-  const formatValue = (num: number) => {
-    if (!formatCompact) return num.toString()
-    if (num >= 1000000) return `${(num / 1000000).toFixed(1)}M`
-    if (num >= 1000) return `${(num / 1000).toFixed(1)}K`
-    return num.toString()
-  }
+function prefersReducedMotion(): boolean {
+  if (typeof window === 'undefined') return false
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+}
+
+/**
+ * Smoothly ticks a number toward `value` and flashes when it increases.
+ */
+export function AnimatedCounter({
+  value,
+  className,
+  formatCompact = false,
+  suffix = '',
+  emptyLabel,
+  showZero = true,
+  durationMs = 700,
+}: AnimatedCounterProps) {
+  const [displayValue, setDisplayValue] = useState(value)
+  const [bump, setBump] = useState(false)
+  const prevValueRef = useRef(value)
+  const rafRef = useRef<number | null>(null)
+  const bumpTimerRef = useRef<number | null>(null)
 
   useEffect(() => {
-    if (value !== prevValueRef.current) {
-      setIsAnimating(true)
+    const previous = prevValueRef.current
+    if (value === previous) return
 
-      // Animate the counter up to new value
-      const startValue = prevValueRef.current
-      const endValue = value
-      const duration = 800 // ms
-      const startTime = Date.now()
-
-      const animate = () => {
-        const elapsed = Date.now() - startTime
-        const progress = Math.min(elapsed / duration, 1)
-
-        // Easing function for smooth animation
-        const easeOut = 1 - Math.pow(1 - progress, 3)
-        const currentValue = Math.round(startValue + (endValue - startValue) * easeOut)
-
-        setDisplayValue(currentValue)
-
-        if (progress < 1) {
-          requestAnimationFrame(animate)
-        } else {
-          setDisplayValue(endValue)
-          setIsAnimating(false)
-          prevValueRef.current = endValue
-        }
-      }
-
-      animate()
+    if (rafRef.current != null) {
+      cancelAnimationFrame(rafRef.current)
+      rafRef.current = null
     }
-  }, [value])
+
+    const increased = value > previous
+    if (increased) {
+      setBump(true)
+      if (bumpTimerRef.current != null) window.clearTimeout(bumpTimerRef.current)
+      bumpTimerRef.current = window.setTimeout(() => setBump(false), 900)
+    }
+
+    if (prefersReducedMotion()) {
+      setDisplayValue(value)
+      prevValueRef.current = value
+      return
+    }
+
+    const startValue = previous
+    const endValue = value
+    const startTime = performance.now()
+    const duration = Math.min(1200, Math.max(280, durationMs))
+
+    const animate = (now: number) => {
+      const progress = Math.min((now - startTime) / duration, 1)
+      // ease-out cubic
+      const ease = 1 - (1 - progress) ** 3
+      const current = startValue + (endValue - startValue) * ease
+      setDisplayValue(current)
+
+      if (progress < 1) {
+        rafRef.current = requestAnimationFrame(animate)
+      } else {
+        setDisplayValue(endValue)
+        prevValueRef.current = endValue
+        rafRef.current = null
+      }
+    }
+
+    rafRef.current = requestAnimationFrame(animate)
+
+    return () => {
+      if (rafRef.current != null) cancelAnimationFrame(rafRef.current)
+    }
+  }, [value, durationMs])
+
+  useEffect(() => {
+    return () => {
+      if (bumpTimerRef.current != null) window.clearTimeout(bumpTimerRef.current)
+      if (rafRef.current != null) cancelAnimationFrame(rafRef.current)
+    }
+  }, [])
+
+  const rounded = Math.round(displayValue)
+  if (!showZero && rounded <= 0 && emptyLabel) {
+    return <span className={className}>{emptyLabel}</span>
+  }
+
+  const text = formatCompact
+    ? formatCompactNumber(displayValue)
+    : String(rounded)
 
   return (
     <span
       className={cn(
-        "transition-all duration-300",
-        isAnimating && "text-emerald-500 scale-110",
+        'inline-block tabular-nums transition-[color,transform] duration-300 ease-out',
+        bump && 'scale-110 text-primary',
         className
       )}
+      data-bump={bump || undefined}
     >
-      {formatValue(displayValue)}
+      {text}
+      {suffix}
     </span>
   )
 }

--- a/components/atoms/theme-toggle.tsx
+++ b/components/atoms/theme-toggle.tsx
@@ -18,9 +18,9 @@ export function ThemeToggle() {
   )
 
   return (
-    <div className="relative flex h-8 w-[96px] items-center justify-between rounded-md border border-[color:var(--soft-border)] bg-secondary/40">
+    <div className="relative flex h-8 w-[96px] items-center justify-between rounded-md border border-border bg-card">
       <div
-        className="absolute h-7 w-7 rounded-sm bg-background shadow-[var(--soft-shadow)] transition-transform duration-200"
+        className="absolute h-7 w-7 rounded-sm border border-border bg-background transition-transform duration-200"
         style={{
           transform: `translateX(calc(${activeIndex * 32}px + 2px))`,
         }}

--- a/components/atoms/theme-toggle.tsx
+++ b/components/atoms/theme-toggle.tsx
@@ -1,46 +1,77 @@
-"use client"
+'use client'
 
-import { useTheme } from "@/hooks/use-theme"
-import { Monitor, Sun, Moon } from "lucide-react"
+import { Monitor, Moon, Sun } from 'lucide-react'
+import { useTheme, type Theme } from '@/hooks/use-theme'
+import { cn } from '@/lib/utils'
 
-export function ThemeToggle() {
-  const { theme, setTheme } = useTheme()
+const OPTIONS: Array<{
+  value: Theme
+  icon: typeof Moon
+  label: string
+  short: string
+}> = [
+  { value: 'dark', icon: Moon, label: 'Dark', short: 'Dark' },
+  { value: 'light', icon: Sun, label: 'Light', short: 'Light' },
+  { value: 'system', icon: Monitor, label: 'System', short: 'Auto' },
+]
 
-  const themes = [
-    { value: "dark" as const, icon: Moon, label: "Switch to dark theme" },
-    { value: "light" as const, icon: Sun, label: "Switch to light theme" },
-    { value: "system" as const, icon: Monitor, label: "Switch to system theme" },
-  ]
-
+/**
+ * Compact segmented theme control — bevel track + sliding active pill.
+ */
+export function ThemeToggle({ className }: { className?: string }) {
+  const { theme, setTheme, mounted } = useTheme()
   const activeIndex = Math.max(
     0,
-    themes.findIndex((t) => t.value === theme)
+    OPTIONS.findIndex((option) => option.value === theme)
   )
 
   return (
-    <div className="relative flex h-8 w-[96px] items-center justify-between rounded-md border border-border bg-card">
+    <div
+      role="radiogroup"
+      aria-label="Color theme"
+      className={cn(
+        'relative inline-flex h-8 items-stretch rounded-[8px] bg-[var(--ui-paper-subtle)] p-0.5 shadow-[var(--shadow-control)]',
+        className
+      )}
+      data-mounted={mounted || undefined}
+    >
+      {/* Sliding active pill */}
       <div
-        className="absolute h-7 w-7 rounded-sm border border-border bg-background transition-transform duration-200"
+        aria-hidden
+        className="pointer-events-none absolute top-0.5 bottom-0.5 w-[calc((100%-4px)/3)] rounded-[6px] bg-[var(--ui-paper)] shadow-[var(--shadow-control)] transition-transform duration-200 ease-out"
         style={{
-          transform: `translateX(calc(${activeIndex * 32}px + 2px))`,
+          transform: `translateX(calc(${activeIndex} * 100%))`,
+          left: 2,
         }}
       />
 
-      {themes.map((themeOption) => {
-        const Icon = themeOption.icon
-        const isActive = theme === themeOption.value
-
+      {OPTIONS.map((option) => {
+        const Icon = option.icon
+        const active = theme === option.value
         return (
           <button
-            key={themeOption.value}
-            onClick={() => setTheme(themeOption.value)}
-            className={`relative z-10 flex h-8 w-8 items-center justify-center transition-colors duration-200 ${
-              isActive ? "text-foreground" : "text-muted-foreground hover:text-foreground"
-            }`}
-            aria-label={themeOption.label}
-            title={themeOption.label}
+            key={option.value}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            aria-label={option.label}
+            title={option.label}
+            onClick={() => setTheme(option.value)}
+            className={cn(
+              'relative z-10 flex h-7 min-w-[30px] flex-1 items-center justify-center gap-1 rounded-[6px] px-1.5 text-[11px] font-medium transition-colors duration-150',
+              active
+                ? 'text-[var(--ui-ink)]'
+                : 'text-[var(--ui-ink-muted)] hover:text-[var(--ui-ink-secondary)]'
+            )}
           >
-            <Icon className="h-3.5 w-3.5" />
+            <Icon
+              className={cn(
+                'size-3.5 shrink-0',
+                active && 'text-[var(--ui-accent)]'
+              )}
+              aria-hidden
+            />
+            <span className="sr-only sm:not-sr-only sm:inline">{option.short}</span>
           </button>
         )
       })}

--- a/components/molecules/app-stats-header.tsx
+++ b/components/molecules/app-stats-header.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useStatsStore } from '@/stores/stats-store'
+import { cn } from '@/lib/utils'
+
+function formatCompact(value: number): string {
+  if (!Number.isFinite(value) || value < 0) return '0'
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1).replace(/\.0$/, '')}M`
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1).replace(/\.0$/, '')}k`
+  return String(Math.round(value))
+}
+
+function StatItem({
+  label,
+  value,
+  emphasize,
+}: {
+  label: string
+  value: string
+  emphasize?: boolean
+}) {
+  return (
+    <div className="flex items-baseline gap-1.5 whitespace-nowrap">
+      <span
+        className={cn(
+          'font-mono text-[11px] font-semibold tabular-nums tracking-tight',
+          emphasize ? 'text-primary' : 'text-foreground'
+        )}
+      >
+        {value}
+      </span>
+      <span className="text-[10px] uppercase tracking-[0.08em] text-muted-foreground">
+        {label}
+      </span>
+    </div>
+  )
+}
+
+/**
+ * Live Redis-backed platform counters shown under the app chrome header.
+ */
+export function AppStatsHeader({ className }: { className?: string }) {
+  const stats = useStatsStore((s) => s.stats)
+  const startPolling = useStatsStore((s) => s.startPolling)
+
+  useEffect(() => startPolling(15_000), [startPolling])
+
+  const sites = stats?.sites ?? 0
+  const scans = stats?.scans ?? 0
+  const tokens = stats?.tokens ?? 0
+  const opens = stats?.contractOpens ?? 0
+  const chats = stats?.chatMessages ?? 0
+  const downloads = stats?.downloads ?? 0
+  const libraryViews = stats?.libraryViews ?? 0
+  const confidence = stats?.avgConfidence ?? 0
+  const mode = stats?.storage.mode ?? '…'
+  const redisLive = Boolean(stats?.storage.redis)
+
+  return (
+    <div
+      className={cn(
+        'flex h-9 shrink-0 items-center gap-3 overflow-x-auto border-b border-border bg-[var(--sidebar)]/40 px-3 scrollbar-none sm:gap-4 sm:px-4',
+        className
+      )}
+      aria-label="Platform stats"
+    >
+      <StatItem label="sites" value={formatCompact(sites)} emphasize={sites > 0} />
+      <StatItem label="scans" value={formatCompact(scans)} />
+      <StatItem label="tokens" value={formatCompact(tokens)} />
+      <StatItem label="opens" value={formatCompact(opens)} />
+      <StatItem label="chats" value={formatCompact(chats)} />
+      <StatItem label="views" value={formatCompact(libraryViews)} />
+      <StatItem label="zips" value={formatCompact(downloads)} />
+      <StatItem
+        label="conf"
+        value={confidence > 0 ? `${Math.round(confidence * 100)}%` : '—'}
+      />
+      <div
+        className="ml-auto hidden items-center gap-1.5 sm:flex"
+        title={
+          redisLive
+            ? 'Live counters from Upstash Redis'
+            : 'Redis not configured — set UPSTASH_REDIS_REST_URL + UPSTASH_REDIS_REST_TOKEN'
+        }
+      >
+        <span
+          className={cn(
+            'size-1.5 rounded-full',
+            redisLive ? 'bg-emerald-600' : 'bg-amber-500'
+          )}
+        />
+        <span className="font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground">
+          {mode}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/components/molecules/app-stats-header.tsx
+++ b/components/molecules/app-stats-header.tsx
@@ -27,8 +27,8 @@ function StatItem({
   return (
     <div
       className={cn(
-        'relative flex items-baseline gap-1.5 whitespace-nowrap rounded-md px-1.5 py-0.5 transition-colors duration-300',
-        bumped && 'bg-primary/10'
+        'relative flex items-baseline gap-1.5 whitespace-nowrap rounded-[6px] px-1.5 py-0.5 transition-colors duration-300',
+        bumped && 'bg-[var(--ui-accent-soft)]'
       )}
     >
       <AnimatedCounter
@@ -38,16 +38,16 @@ function StatItem({
         emptyLabel={emptyLabel}
         showZero={!emptyLabel}
         className={cn(
-          'font-mono text-[11px] font-semibold tracking-tight',
-          emphasize || bumped ? 'text-primary' : 'text-foreground'
+          'font-mono text-[11px] font-semibold tracking-tight font-tabular',
+          emphasize || bumped ? 'text-[var(--ui-accent)]' : 'text-[var(--ui-ink)]'
         )}
       />
-      <span className="text-[10px] uppercase tracking-[0.08em] text-muted-foreground">
+      <span className="text-[10px] uppercase tracking-[0.08em] text-[var(--ui-ink-muted)]">
         {label}
       </span>
       {bumped ? (
         <span
-          className="pointer-events-none absolute -right-0.5 -top-1 font-mono text-[9px] font-semibold text-primary animate-in fade-in-0 zoom-in-95 duration-300"
+          className="pointer-events-none absolute -right-0.5 -top-1 font-mono text-[9px] font-semibold text-[var(--ui-accent)] animate-in fade-in-0 zoom-in-95 duration-300"
           aria-hidden
         >
           +
@@ -58,7 +58,7 @@ function StatItem({
 }
 
 /**
- * Live Redis-backed platform counters with tick-up animations.
+ * Live Redis-backed platform counters — integrated paper toolbar strip.
  */
 export function AppStatsHeader({ className }: { className?: string }) {
   const stats = useStatsStore((s) => s.stats)
@@ -68,7 +68,6 @@ export function AppStatsHeader({ className }: { className?: string }) {
 
   useEffect(() => startPolling(4_000), [startPolling])
 
-  // Optimistic bumps when this tab tracks an event
   useEffect(() => {
     const onBump = (event: Event) => {
       const detail = (event as CustomEvent<StatsBumpDetail>).detail
@@ -100,7 +99,7 @@ export function AppStatsHeader({ className }: { className?: string }) {
   return (
     <div
       className={cn(
-        'flex h-9 shrink-0 items-center gap-2 overflow-x-auto border-b border-border bg-[var(--sidebar)]/40 px-2 scrollbar-none sm:gap-3 sm:px-3',
+        'flex h-9 w-full items-center gap-1.5 overflow-x-auto px-2 scrollbar-none sm:gap-2 sm:px-3',
         className
       )}
       aria-label="Platform stats"
@@ -124,25 +123,25 @@ export function AppStatsHeader({ className }: { className?: string }) {
         className="ml-auto hidden items-center gap-1.5 sm:flex"
         title={
           redisLive
-            ? 'Live counters from Upstash Redis — updates every few seconds'
+            ? 'Live counters from Upstash Redis'
             : 'Redis not configured — set UPSTASH_REDIS_REST_URL + UPSTASH_REDIS_REST_TOKEN'
         }
       >
         <span className="relative flex size-1.5">
           <span
             className={cn(
-              'absolute inline-flex size-full animate-ping rounded-full opacity-60',
-              redisLive ? 'bg-emerald-500' : 'bg-amber-400'
+              'absolute inline-flex size-full animate-ping rounded-full opacity-50',
+              redisLive ? 'bg-[var(--ui-success)]' : 'bg-[var(--ui-warning)]'
             )}
           />
           <span
             className={cn(
               'relative inline-flex size-1.5 rounded-full',
-              redisLive ? 'bg-emerald-600' : 'bg-amber-500'
+              redisLive ? 'bg-[var(--ui-success)]' : 'bg-[var(--ui-warning)]'
             )}
           />
         </span>
-        <span className="font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground">
+        <span className="font-mono text-[10px] uppercase tracking-[0.08em] text-[var(--ui-ink-muted)]">
           {mode}
         </span>
       </div>

--- a/components/molecules/app-stats-header.tsx
+++ b/components/molecules/app-stats-header.tsx
@@ -1,50 +1,85 @@
 'use client'
 
 import { useEffect } from 'react'
-import { useStatsStore } from '@/stores/stats-store'
+import { AnimatedCounter } from '@/components/atoms/animated-counter'
+import {
+  STATS_BUMP_EVENT,
+  type StatsBumpDetail,
+} from '@/lib/analytics/track-client'
+import { useStatsStore, type PlatformStats } from '@/stores/stats-store'
 import { cn } from '@/lib/utils'
-
-function formatCompact(value: number): string {
-  if (!Number.isFinite(value) || value < 0) return '0'
-  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1).replace(/\.0$/, '')}M`
-  if (value >= 1_000) return `${(value / 1_000).toFixed(1).replace(/\.0$/, '')}k`
-  return String(Math.round(value))
-}
 
 function StatItem({
   label,
   value,
   emphasize,
+  bumped,
+  suffix,
+  emptyLabel,
 }: {
   label: string
-  value: string
+  value: number
   emphasize?: boolean
+  bumped?: boolean
+  suffix?: string
+  emptyLabel?: string
 }) {
   return (
-    <div className="flex items-baseline gap-1.5 whitespace-nowrap">
-      <span
+    <div
+      className={cn(
+        'relative flex items-baseline gap-1.5 whitespace-nowrap rounded-md px-1.5 py-0.5 transition-colors duration-300',
+        bumped && 'bg-primary/10'
+      )}
+    >
+      <AnimatedCounter
+        value={value}
+        formatCompact
+        suffix={suffix}
+        emptyLabel={emptyLabel}
+        showZero={!emptyLabel}
         className={cn(
-          'font-mono text-[11px] font-semibold tabular-nums tracking-tight',
-          emphasize ? 'text-primary' : 'text-foreground'
+          'font-mono text-[11px] font-semibold tracking-tight',
+          emphasize || bumped ? 'text-primary' : 'text-foreground'
         )}
-      >
-        {value}
-      </span>
+      />
       <span className="text-[10px] uppercase tracking-[0.08em] text-muted-foreground">
         {label}
       </span>
+      {bumped ? (
+        <span
+          className="pointer-events-none absolute -right-0.5 -top-1 font-mono text-[9px] font-semibold text-primary animate-in fade-in-0 zoom-in-95 duration-300"
+          aria-hidden
+        >
+          +
+        </span>
+      ) : null}
     </div>
   )
 }
 
 /**
- * Live Redis-backed platform counters shown under the app chrome header.
+ * Live Redis-backed platform counters with tick-up animations.
  */
 export function AppStatsHeader({ className }: { className?: string }) {
   const stats = useStatsStore((s) => s.stats)
+  const lastBumpedFields = useStatsStore((s) => s.lastBumpedFields)
   const startPolling = useStatsStore((s) => s.startPolling)
+  const bumpEvent = useStatsStore((s) => s.bumpEvent)
 
-  useEffect(() => startPolling(15_000), [startPolling])
+  useEffect(() => startPolling(4_000), [startPolling])
+
+  // Optimistic bumps when this tab tracks an event
+  useEffect(() => {
+    const onBump = (event: Event) => {
+      const detail = (event as CustomEvent<StatsBumpDetail>).detail
+      if (!detail?.event) return
+      bumpEvent(detail.event, detail.by ?? 1)
+    }
+    window.addEventListener(STATS_BUMP_EVENT, onBump)
+    return () => window.removeEventListener(STATS_BUMP_EVENT, onBump)
+  }, [bumpEvent])
+
+  const bumped = (field: keyof PlatformStats) => lastBumpedFields.includes(field)
 
   const sites = stats?.sites ?? 0
   const scans = stats?.scans ?? 0
@@ -53,43 +88,60 @@ export function AppStatsHeader({ className }: { className?: string }) {
   const chats = stats?.chatMessages ?? 0
   const downloads = stats?.downloads ?? 0
   const libraryViews = stats?.libraryViews ?? 0
-  const confidence = stats?.avgConfidence ?? 0
+  const confidencePct =
+    stats && stats.avgConfidence > 0
+      ? Math.round(
+          stats.avgConfidence > 1 ? stats.avgConfidence : stats.avgConfidence * 100
+        )
+      : 0
   const mode = stats?.storage.mode ?? '…'
   const redisLive = Boolean(stats?.storage.redis)
 
   return (
     <div
       className={cn(
-        'flex h-9 shrink-0 items-center gap-3 overflow-x-auto border-b border-border bg-[var(--sidebar)]/40 px-3 scrollbar-none sm:gap-4 sm:px-4',
+        'flex h-9 shrink-0 items-center gap-2 overflow-x-auto border-b border-border bg-[var(--sidebar)]/40 px-2 scrollbar-none sm:gap-3 sm:px-3',
         className
       )}
       aria-label="Platform stats"
+      aria-live="polite"
     >
-      <StatItem label="sites" value={formatCompact(sites)} emphasize={sites > 0} />
-      <StatItem label="scans" value={formatCompact(scans)} />
-      <StatItem label="tokens" value={formatCompact(tokens)} />
-      <StatItem label="opens" value={formatCompact(opens)} />
-      <StatItem label="chats" value={formatCompact(chats)} />
-      <StatItem label="views" value={formatCompact(libraryViews)} />
-      <StatItem label="zips" value={formatCompact(downloads)} />
+      <StatItem label="sites" value={sites} emphasize={sites > 0} bumped={bumped('sites')} />
+      <StatItem label="scans" value={scans} bumped={bumped('scans')} />
+      <StatItem label="tokens" value={tokens} bumped={bumped('tokens')} />
+      <StatItem label="opens" value={opens} bumped={bumped('contractOpens')} />
+      <StatItem label="chats" value={chats} bumped={bumped('chatMessages')} />
+      <StatItem label="views" value={libraryViews} bumped={bumped('libraryViews')} />
+      <StatItem label="zips" value={downloads} bumped={bumped('downloads')} />
       <StatItem
         label="conf"
-        value={confidence > 0 ? `${Math.round(confidence * 100)}%` : '—'}
+        value={confidencePct}
+        suffix={confidencePct > 0 ? '%' : undefined}
+        emptyLabel="—"
+        bumped={bumped('avgConfidence')}
       />
       <div
         className="ml-auto hidden items-center gap-1.5 sm:flex"
         title={
           redisLive
-            ? 'Live counters from Upstash Redis'
+            ? 'Live counters from Upstash Redis — updates every few seconds'
             : 'Redis not configured — set UPSTASH_REDIS_REST_URL + UPSTASH_REDIS_REST_TOKEN'
         }
       >
-        <span
-          className={cn(
-            'size-1.5 rounded-full',
-            redisLive ? 'bg-emerald-600' : 'bg-amber-500'
-          )}
-        />
+        <span className="relative flex size-1.5">
+          <span
+            className={cn(
+              'absolute inline-flex size-full animate-ping rounded-full opacity-60',
+              redisLive ? 'bg-emerald-500' : 'bg-amber-400'
+            )}
+          />
+          <span
+            className={cn(
+              'relative inline-flex size-1.5 rounded-full',
+              redisLive ? 'bg-emerald-600' : 'bg-amber-500'
+            )}
+          />
+        </span>
         <span className="font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground">
           {mode}
         </span>

--- a/components/molecules/page-canvas.tsx
+++ b/components/molecules/page-canvas.tsx
@@ -1,0 +1,29 @@
+import { cn } from '@/lib/utils'
+
+/**
+ * Scrollable main canvas for non-chat product pages inside AppShell.
+ * See DESIGN.md.
+ */
+export function PageCanvas({
+  children,
+  className,
+  innerClassName,
+}: {
+  children: React.ReactNode
+  className?: string
+  /** Override inner max-width / padding */
+  innerClassName?: string
+}) {
+  return (
+    <div className={cn('min-h-0 flex-1 overflow-y-auto', className)}>
+      <div
+        className={cn(
+          'mx-auto max-w-3xl px-4 py-10 sm:px-6 sm:py-12',
+          innerClassName
+        )}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/components/molecules/page-canvas.tsx
+++ b/components/molecules/page-canvas.tsx
@@ -1,29 +1,37 @@
 import { cn } from '@/lib/utils'
 
+type PageCanvasVariant = 'document' | 'settings' | 'operational' | 'action'
+
+const INNER: Record<PageCanvasVariant, string> = {
+  /** Document + rail — reading column ~760px */
+  document: 'mx-auto max-w-[760px] px-4 py-8 sm:px-6 sm:py-10',
+  /** Settings — 640px */
+  settings: 'mx-auto max-w-[640px] px-4 py-8 sm:px-6 sm:py-10',
+  /** Full operational canvas */
+  operational: 'mx-auto w-full max-w-6xl px-3 py-4 sm:px-4 sm:py-5',
+  /** Centered action / agent welcome — 712px */
+  action: 'mx-auto max-w-[712px] px-4 py-10 sm:px-6',
+}
+
 /**
  * Scrollable main canvas for non-chat product pages inside AppShell.
- * See DESIGN.md.
+ * Warm Paper Workbench — see DESIGN.md.
  */
 export function PageCanvas({
   children,
   className,
   innerClassName,
+  variant = 'document',
 }: {
   children: React.ReactNode
   className?: string
   /** Override inner max-width / padding */
   innerClassName?: string
+  variant?: PageCanvasVariant
 }) {
   return (
     <div className={cn('min-h-0 flex-1 overflow-y-auto', className)}>
-      <div
-        className={cn(
-          'mx-auto max-w-3xl px-4 py-10 sm:px-6 sm:py-12',
-          innerClassName
-        )}
-      >
-        {children}
-      </div>
+      <div className={cn(INNER[variant], innerClassName)}>{children}</div>
     </div>
   )
 }

--- a/components/molecules/scan-result-widget.tsx
+++ b/components/molecules/scan-result-widget.tsx
@@ -72,12 +72,12 @@ export function ScanResultWidget({ data, state, className }: ScanResultWidgetPro
     return (
       <div
         className={cn(
-          'flex items-center gap-2.5 rounded-xl border border-[color:var(--soft-border)] bg-secondary/30 px-3.5 py-3',
+          'flex items-center gap-2.5 rounded-[10px] border border-[var(--ui-border)] bg-[var(--ui-paper)] px-3 py-2.5 shadow-[var(--shadow-paper)]',
           className
         )}
       >
-        <Loader2 className="size-3.5 shrink-0 animate-spin text-muted-foreground" />
-        <p className="text-sm text-muted-foreground">
+        <Loader2 className="size-3.5 shrink-0 animate-spin text-[var(--ui-ink-muted)]" />
+        <p className="text-[13px] text-[var(--ui-ink-secondary)]">
           Scanning{data.domain ? ` ${data.domain}` : ''}…
         </p>
       </div>
@@ -88,12 +88,12 @@ export function ScanResultWidget({ data, state, className }: ScanResultWidgetPro
     return (
       <div
         className={cn(
-          'rounded-xl border border-[color:var(--soft-border)] bg-secondary/30 px-3.5 py-3 text-sm text-muted-foreground',
+          'rounded-[10px] border border-[var(--ui-border)] bg-[var(--ui-paper-subtle)] px-3 py-2.5 text-[13px] text-[var(--ui-ink-secondary)]',
           className
         )}
       >
-        No cached contract for <span className="text-foreground">{data.domain}</span>. Scanning
-        next…
+        No cached contract for <span className="text-[var(--ui-ink)]">{data.domain}</span>.
+        Scanning next…
       </div>
     )
   }
@@ -113,13 +113,13 @@ export function ScanResultWidget({ data, state, className }: ScanResultWidgetPro
   return (
     <div
       className={cn(
-        'overflow-hidden rounded-xl border border-[color:var(--soft-border)] bg-secondary/25',
+        'paper overflow-hidden !rounded-[10px]',
         className
       )}
     >
       <div className="flex items-stretch gap-0">
         {data.screenshots?.[0]?.url ? (
-          <div className="relative hidden w-28 shrink-0 overflow-hidden border-r border-[color:var(--soft-border)] sm:block">
+          <div className="relative hidden w-28 shrink-0 overflow-hidden border-r border-[var(--ui-border-soft)] sm:block">
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
               src={data.screenshots[0].url}
@@ -129,10 +129,10 @@ export function ScanResultWidget({ data, state, className }: ScanResultWidgetPro
           </div>
         ) : null}
 
-        <div className="flex min-w-0 flex-1 flex-col gap-2.5 px-3.5 py-3">
+        <div className="flex min-w-0 flex-1 flex-col gap-2 px-3 py-2.5">
           <div className="flex items-start justify-between gap-3">
             <div className="min-w-0">
-              <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+              <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-[var(--ui-ink-muted)]">
                 Contract
                 {typeof confidence === 'number' ? ` · ${Math.round(confidence)}%` : ''}
                 {data.mode ? ` · ${data.mode}` : ''}
@@ -142,14 +142,14 @@ export function ScanResultWidget({ data, state, className }: ScanResultWidgetPro
                     ? ` · ${data.browserEngine}`
                     : ''}
               </p>
-              <p className="mt-0.5 truncate font-medium tracking-tight text-foreground">
+              <p className="mt-0.5 truncate text-[14px] font-medium tracking-tight text-[var(--ui-ink)]">
                 {domain}
               </p>
             </div>
             <Link
               href={`/site/${domain}` as `/site/${string}`}
               onClick={() => stashSiteHandoff(domain, data)}
-              className="inline-flex shrink-0 items-center gap-1 rounded-md px-2 py-1 text-xs text-muted-foreground transition hover:bg-secondary hover:text-foreground"
+              className="inline-flex h-7 shrink-0 items-center gap-1 rounded-[7px] bg-[var(--ui-paper)] px-2 text-[12px] text-[var(--ui-ink-secondary)] shadow-[var(--shadow-control)] transition hover:bg-[var(--ui-paper-hover)] hover:text-[var(--ui-ink)]"
             >
               Open
               <ArrowUpRight className="size-3.5" />
@@ -162,18 +162,18 @@ export function ScanResultWidget({ data, state, className }: ScanResultWidgetPro
                 <span
                   key={value}
                   title={value}
-                  className="size-4 rounded-sm border border-white/10"
+                  className="size-3.5 rounded-[3px] border border-[var(--ui-border-soft)]"
                   style={{ backgroundColor: value }}
                 />
               ))}
-              <span className="ml-2 truncate font-mono text-[11px] text-muted-foreground">
+              <span className="ml-2 truncate font-mono text-[11px] text-[var(--ui-ink-muted)]">
                 {[tokenCount ? `${tokenCount} tokens` : null, font].filter(Boolean).join(' · ')}
               </span>
             </div>
           ) : null}
 
           {install ? (
-            <code className="block truncate font-mono text-[11px] text-muted-foreground">
+            <code className="block truncate font-mono text-[11px] text-[var(--ui-ink-muted)]">
               {install}
             </code>
           ) : null}

--- a/components/molecules/scan-result-widget.tsx
+++ b/components/molecules/scan-result-widget.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link'
 import { ArrowUpRight, Loader2 } from 'lucide-react'
+import { stashSiteHandoff } from '@/lib/site-handoff'
 import { cn } from '@/lib/utils'
 
 export type ScanWidgetPayload = {
@@ -147,6 +148,7 @@ export function ScanResultWidget({ data, state, className }: ScanResultWidgetPro
             </div>
             <Link
               href={`/site/${domain}` as `/site/${string}`}
+              onClick={() => stashSiteHandoff(domain, data)}
               className="inline-flex shrink-0 items-center gap-1 rounded-md px-2 py-1 text-xs text-muted-foreground transition hover:bg-secondary hover:text-foreground"
             >
               Open

--- a/components/molecules/scan-result-widget.tsx
+++ b/components/molecules/scan-result-widget.tsx
@@ -76,7 +76,7 @@ export function ScanResultWidget({ data, state, className }: ScanResultWidgetPro
           className
         )}
       >
-        <Loader2 className="size-3.5 shrink-0 animate-spin text-[oklch(0.78_0.08_185)]" />
+        <Loader2 className="size-3.5 shrink-0 animate-spin text-muted-foreground" />
         <p className="text-sm text-muted-foreground">
           Scanning{data.domain ? ` ${data.domain}` : ''}…
         </p>

--- a/components/organisms/app-shell.tsx
+++ b/components/organisms/app-shell.tsx
@@ -181,11 +181,13 @@ function SidebarBody({
         </div>
       </nav>
 
-      <div className="mt-1 flex items-center justify-between border-t border-[var(--ui-border-soft)] px-1 pt-2">
-        <span className="px-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-[var(--ui-ink-muted)]">
-          App
-        </span>
-        <ThemeToggle />
+      <div className="mt-1 flex flex-col gap-2 border-t border-[var(--ui-border-soft)] px-1 pt-2">
+        <div className="flex items-center justify-between px-1">
+          <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[var(--ui-ink-muted)]">
+            Theme
+          </span>
+        </div>
+        <ThemeToggle className="w-full" />
       </div>
     </div>
   )

--- a/components/organisms/app-shell.tsx
+++ b/components/organisms/app-shell.tsx
@@ -17,7 +17,18 @@ import { Button } from '@/components/ui/button'
 import { pushRecent, readRecents, type RecentDomain } from '@/lib/recents'
 import { cn } from '@/lib/utils'
 
-export type AppShellPage = 'chat' | 'library' | 'docs' | 'site'
+export type AppShellPage =
+  | 'chat'
+  | 'library'
+  | 'docs'
+  | 'site'
+  | 'features'
+  | 'pricing'
+  | 'about'
+  | 'contact'
+  | 'privacy'
+  | 'terms'
+  | 'metrics'
 
 type AppShellProps = {
   currentPage: AppShellPage
@@ -31,6 +42,18 @@ const PRIMARY_NAV = [
   { href: '/', label: 'Chat', page: 'chat' as const, icon: MessageSquare },
   { href: '/community', label: 'Library', page: 'library' as const, icon: Library },
   { href: '/docs', label: 'Docs', page: 'docs' as const, icon: BookOpen },
+] as const
+
+const MORE_NAV = [
+  { href: '/features', label: 'Features', page: 'features' as const },
+  { href: '/pricing', label: 'Pricing', page: 'pricing' as const },
+  { href: '/about', label: 'About', page: 'about' as const },
+] as const
+
+const LEGAL_LINKS = [
+  { href: '/contact', label: 'Contact', page: 'contact' as const },
+  { href: '/privacy', label: 'Privacy', page: 'privacy' as const },
+  { href: '/terms', label: 'Terms', page: 'terms' as const },
 ] as const
 
 function SidebarBody({
@@ -114,7 +137,49 @@ function SidebarBody({
         </ul>
       </div>
 
-      <div className="mt-auto flex items-center justify-between border-t border-sidebar-border px-1 pt-2">
+      <nav className="mt-2 flex flex-col gap-0.5 border-t border-sidebar-border pt-2" aria-label="More">
+        <p className="px-2.5 pb-1 font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+          More
+        </p>
+        {MORE_NAV.map((item) => {
+          const active = currentPage === item.page
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              onClick={onNavigate}
+              className={cn(
+                'rounded-lg px-2.5 py-1.5 text-sm transition-colors',
+                active
+                  ? 'bg-sidebar-accent text-sidebar-accent-foreground'
+                  : 'text-muted-foreground hover:bg-sidebar-accent/50 hover:text-sidebar-foreground'
+              )}
+              aria-current={active ? 'page' : undefined}
+            >
+              {item.label}
+            </Link>
+          )
+        })}
+        <div className="mt-1 flex flex-wrap gap-x-2.5 gap-y-1 px-2.5 pb-1">
+          {LEGAL_LINKS.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              onClick={onNavigate}
+              className={cn(
+                'font-mono text-[10px] uppercase tracking-[0.08em] transition-colors',
+                currentPage === item.page
+                  ? 'text-sidebar-foreground'
+                  : 'text-muted-foreground/80 hover:text-sidebar-foreground'
+              )}
+            >
+              {item.label}
+            </Link>
+          ))}
+        </div>
+      </nav>
+
+      <div className="mt-1 flex items-center justify-between border-t border-sidebar-border px-1 pt-2">
         <span className="px-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
           App
         </span>

--- a/components/organisms/app-shell.tsx
+++ b/components/organisms/app-shell.tsx
@@ -71,23 +71,21 @@ function SidebarBody({
       <Link
         href="/"
         onClick={onNavigate}
-        className="mb-2 flex items-baseline gap-0.5 rounded-lg px-2 py-1.5 outline-offset-4 transition-opacity hover:opacity-90"
+        className="mb-1 flex items-baseline gap-0.5 rounded-[7px] px-2 py-1.5 outline-offset-4 transition-colors hover:bg-[var(--ui-paper-hover)]"
         aria-label="designcontracts.sh home"
       >
-        <span className="text-[15px] font-normal tracking-tight text-sidebar-foreground">
+        <span className="text-[15px] font-medium tracking-tight text-[var(--ui-ink)]">
           designcontracts
         </span>
-        <span className="font-mono text-[10px] text-primary">.sh</span>
+        <span className="font-mono text-[10px] text-[var(--ui-accent)]">.sh</span>
       </Link>
 
-      <Link
-        href="/"
-        onClick={onNavigate}
-        className="mb-2 inline-flex items-center gap-2 rounded-lg bg-primary px-2.5 py-2 text-sm font-medium text-primary-foreground transition hover:bg-[var(--primary-active)]"
-      >
-        <Plus className="size-3.5 opacity-90" aria-hidden />
-        New chat
-      </Link>
+      <Button asChild size="sm" className="mb-2 w-full justify-start gap-2">
+        <Link href="/" onClick={onNavigate}>
+          <Plus className="size-3.5 opacity-90" aria-hidden />
+          New chat
+        </Link>
+      </Button>
 
       <nav className="flex flex-col gap-0.5" aria-label="Primary">
         {PRIMARY_NAV.map((item) => {
@@ -99,14 +97,14 @@ function SidebarBody({
               href={item.href}
               onClick={onNavigate}
               className={cn(
-                'flex items-center gap-2.5 rounded-lg px-2.5 py-2 text-sm transition-colors',
+                'flex h-8 items-center gap-2.5 rounded-[7px] px-2.5 text-[13px] transition-colors',
                 active
-                  ? 'bg-sidebar-accent text-sidebar-accent-foreground'
-                  : 'text-muted-foreground hover:bg-sidebar-accent/50 hover:text-sidebar-foreground'
+                  ? 'bg-[var(--ui-paper-selected)] text-[var(--ui-ink)]'
+                  : 'text-[var(--ui-ink-secondary)] hover:bg-[var(--ui-paper-hover)] hover:text-[var(--ui-ink)]'
               )}
               aria-current={active ? 'page' : undefined}
             >
-              <Icon className="size-4 shrink-0 opacity-80" aria-hidden />
+              <Icon className="size-3.5 shrink-0 opacity-80" aria-hidden />
               {item.label}
             </Link>
           )
@@ -114,12 +112,12 @@ function SidebarBody({
       </nav>
 
       <div className="mt-4 flex min-h-0 flex-1 flex-col">
-        <p className="px-2.5 pb-1.5 font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+        <p className="px-2.5 pb-1 font-mono text-[10px] uppercase tracking-[0.14em] text-[var(--ui-ink-muted)]">
           Recents
         </p>
         <ul className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto">
           {recents.length === 0 ? (
-            <li className="px-2.5 py-1.5 text-xs text-muted-foreground/80">
+            <li className="px-2.5 py-1.5 text-xs text-[var(--ui-ink-muted)]">
               Scanned sites show up here
             </li>
           ) : (
@@ -128,7 +126,7 @@ function SidebarBody({
                 <Link
                   href={`/site/${item.domain}` as `/site/${string}`}
                   onClick={onNavigate}
-                  className="block truncate rounded-lg px-2.5 py-1.5 font-mono text-xs text-muted-foreground transition hover:bg-sidebar-accent/50 hover:text-sidebar-foreground"
+                  className="block h-7 truncate rounded-[7px] px-2.5 font-mono text-[12px] leading-7 text-[var(--ui-ink-secondary)] transition hover:bg-[var(--ui-paper-hover)] hover:text-[var(--ui-ink)]"
                 >
                   {item.domain}
                 </Link>
@@ -138,8 +136,11 @@ function SidebarBody({
         </ul>
       </div>
 
-      <nav className="mt-2 flex flex-col gap-0.5 border-t border-sidebar-border pt-2" aria-label="More">
-        <p className="px-2.5 pb-1 font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+      <nav
+        className="mt-2 flex flex-col gap-0.5 border-t border-[var(--ui-border-soft)] pt-2"
+        aria-label="More"
+      >
+        <p className="px-2.5 pb-1 font-mono text-[10px] uppercase tracking-[0.14em] text-[var(--ui-ink-muted)]">
           More
         </p>
         {MORE_NAV.map((item) => {
@@ -150,10 +151,10 @@ function SidebarBody({
               href={item.href}
               onClick={onNavigate}
               className={cn(
-                'rounded-lg px-2.5 py-1.5 text-sm transition-colors',
+                'flex h-7 items-center rounded-[7px] px-2.5 text-[13px] transition-colors',
                 active
-                  ? 'bg-sidebar-accent text-sidebar-accent-foreground'
-                  : 'text-muted-foreground hover:bg-sidebar-accent/50 hover:text-sidebar-foreground'
+                  ? 'bg-[var(--ui-paper-selected)] text-[var(--ui-ink)]'
+                  : 'text-[var(--ui-ink-secondary)] hover:bg-[var(--ui-paper-hover)] hover:text-[var(--ui-ink)]'
               )}
               aria-current={active ? 'page' : undefined}
             >
@@ -170,8 +171,8 @@ function SidebarBody({
               className={cn(
                 'font-mono text-[10px] uppercase tracking-[0.08em] transition-colors',
                 currentPage === item.page
-                  ? 'text-sidebar-foreground'
-                  : 'text-muted-foreground/80 hover:text-sidebar-foreground'
+                  ? 'text-[var(--ui-ink)]'
+                  : 'text-[var(--ui-ink-muted)] hover:text-[var(--ui-ink)]'
               )}
             >
               {item.label}
@@ -180,8 +181,8 @@ function SidebarBody({
         </div>
       </nav>
 
-      <div className="mt-1 flex items-center justify-between border-t border-sidebar-border px-1 pt-2">
-        <span className="px-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+      <div className="mt-1 flex items-center justify-between border-t border-[var(--ui-border-soft)] px-1 pt-2">
+        <span className="px-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-[var(--ui-ink-muted)]">
           App
         </span>
         <ThemeToggle />
@@ -191,8 +192,8 @@ function SidebarBody({
 }
 
 /**
- * Full-viewport product chrome: sidebar + main canvas. No marketing footer.
- * See DESIGN.md.
+ * Warm Paper Workbench shell:
+ * outer canvas → 240px sidebar → inset paper workspace (toolbar/stats + body).
  */
 export function AppShell({
   currentPage,
@@ -216,27 +217,27 @@ export function AppShell({
   return (
     <div
       className={cn(
-        'flex h-dvh max-h-dvh overflow-hidden bg-background text-foreground',
+        'flex h-dvh max-h-dvh overflow-hidden bg-[var(--ui-canvas)] text-[var(--ui-ink)]',
         className
       )}
     >
-      {/* Desktop sidebar */}
+      {/* Global sidebar on canvas */}
       <aside
         className={cn(
-          'relative z-20 hidden shrink-0 flex-col border-r border-sidebar-border bg-sidebar md:flex',
+          'relative z-20 hidden shrink-0 flex-col md:flex',
           collapsed ? 'w-[52px]' : 'w-[240px]'
         )}
         aria-label="App sidebar"
       >
         {collapsed ? (
-          <div className="flex h-full flex-col items-center gap-2 px-1.5 py-3">
+          <div className="flex h-full flex-col items-center gap-1.5 px-1.5 py-3">
             <Link
               href="/"
-              className="flex size-9 items-center justify-center rounded-lg text-sm font-normal text-sidebar-foreground hover:bg-sidebar-accent"
+              className="flex size-8 items-center justify-center rounded-[7px] text-sm font-medium text-[var(--ui-ink)] hover:bg-[var(--ui-paper-hover)]"
               aria-label="Chat"
             >
               <span>
-                d<span className="text-primary">.</span>
+                d<span className="text-[var(--ui-accent)]">.</span>
               </span>
             </Link>
             {PRIMARY_NAV.map((item) => {
@@ -248,13 +249,13 @@ export function AppShell({
                   href={item.href}
                   title={item.label}
                   className={cn(
-                    'flex size-9 items-center justify-center rounded-lg transition',
+                    'flex size-8 items-center justify-center rounded-[7px] transition',
                     active
-                      ? 'bg-sidebar-accent text-sidebar-accent-foreground'
-                      : 'text-muted-foreground hover:bg-sidebar-accent/50 hover:text-sidebar-foreground'
+                      ? 'bg-[var(--ui-paper-selected)] text-[var(--ui-ink)]'
+                      : 'text-[var(--ui-ink-secondary)] hover:bg-[var(--ui-paper-hover)] hover:text-[var(--ui-ink)]'
                   )}
                 >
-                  <Icon className="size-4" />
+                  <Icon className="size-3.5" />
                 </Link>
               )
             })}
@@ -265,7 +266,7 @@ export function AppShell({
               onClick={() => setCollapsed(false)}
               aria-label="Expand sidebar"
             >
-              <PanelLeft className="size-4" />
+              <PanelLeft className="size-3.5" />
             </Button>
           </div>
         ) : (
@@ -278,7 +279,7 @@ export function AppShell({
               onClick={() => setCollapsed(true)}
               aria-label="Collapse sidebar"
             >
-              <PanelLeftClose className="size-4" />
+              <PanelLeftClose className="size-3.5" />
             </Button>
           </div>
         )}
@@ -289,11 +290,11 @@ export function AppShell({
         <div className="fixed inset-0 z-40 md:hidden">
           <button
             type="button"
-            className="absolute inset-0 bg-black/50"
+            className="absolute inset-0 bg-[rgba(43,39,35,0.35)]"
             aria-label="Close menu"
             onClick={() => setMobileOpen(false)}
           />
-          <aside className="absolute inset-y-0 left-0 flex w-[min(280px,88vw)] flex-col bg-sidebar shadow-xl">
+          <aside className="absolute inset-y-0 left-0 flex w-[min(280px,88vw)] flex-col border-r border-[var(--ui-border-edge)] bg-[var(--ui-canvas)] shadow-[var(--shadow-float)]">
             <SidebarBody
               currentPage={currentPage}
               recents={recents}
@@ -303,28 +304,37 @@ export function AppShell({
         </div>
       ) : null}
 
-      <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
-        <header className="flex h-12 shrink-0 items-center gap-2 border-b border-border px-3 md:hidden">
-          <Button
-            variant="ghost"
-            size="icon-sm"
-            onClick={() => setMobileOpen(true)}
-            aria-label="Open menu"
+      {/* Inset paper workspace */}
+      <div className="flex min-w-0 flex-1 flex-col p-0 md:p-2 md:pl-0">
+        <div className="paper paper--shell flex min-h-0 flex-1 flex-col rounded-none border-0 shadow-none md:rounded-[var(--radius-shell)] md:border md:shadow-[var(--shadow-paper)]">
+          {/* Mobile location bar */}
+          <header className="paper__toolbar flex h-11 shrink-0 items-center gap-2 border-b border-[var(--ui-border-soft)] px-2 md:hidden">
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              onClick={() => setMobileOpen(true)}
+              aria-label="Open menu"
+            >
+              {mobileOpen ? <X className="size-3.5" /> : <Menu className="size-3.5" />}
+            </Button>
+            <Link href="/" className="flex items-baseline gap-0.5">
+              <span className="text-[15px] font-medium tracking-tight">designcontracts</span>
+              <span className="font-mono text-[10px] text-[var(--ui-accent)]">.sh</span>
+            </Link>
+          </header>
+
+          {/* Utility strip — live Redis stats */}
+          <div className="paper__toolbar !min-h-9 !px-0 !py-0">
+            <AppStatsHeader className="w-full border-0 bg-transparent" />
+          </div>
+
+          <main
+            className="flex min-h-0 flex-1 flex-col overflow-hidden bg-[var(--ui-paper)]"
+            id="main-content"
           >
-            {mobileOpen ? <X className="size-4" /> : <Menu className="size-4" />}
-          </Button>
-          <Link href="/" className="flex items-baseline gap-0.5">
-            <span className="text-base font-normal tracking-tight">designcontracts</span>
-            <span className="font-mono text-[10px] text-primary">.sh</span>
-          </Link>
-        </header>
-
-        {/* Desktop + mobile: Redis-backed live platform stats */}
-        <AppStatsHeader />
-
-        <main className="flex min-h-0 flex-1 flex-col overflow-hidden" id="main-content">
-          {children}
-        </main>
+            {children}
+          </main>
+        </div>
       </div>
     </div>
   )

--- a/components/organisms/app-shell.tsx
+++ b/components/organisms/app-shell.tsx
@@ -76,7 +76,7 @@ function SidebarBody({
         <span className="font-serif text-[15px] tracking-tight text-sidebar-foreground">
           designcontracts
         </span>
-        <span className="font-mono text-[10px] text-[oklch(0.78_0.08_185)]">.sh</span>
+        <span className="font-mono text-[10px] text-muted-foreground">.sh</span>
       </Link>
 
       <Link
@@ -312,7 +312,7 @@ export function AppShell({
           </Button>
           <Link href="/" className="flex items-baseline gap-0.5">
             <span className="font-serif text-base tracking-tight">designcontracts</span>
-            <span className="font-mono text-[10px] text-[oklch(0.78_0.08_185)]">.sh</span>
+            <span className="font-mono text-[10px] text-muted-foreground">.sh</span>
           </Link>
         </header>
 

--- a/components/organisms/app-shell.tsx
+++ b/components/organisms/app-shell.tsx
@@ -13,6 +13,7 @@ import {
   X,
 } from 'lucide-react'
 import { ThemeToggle } from '@/components/atoms/theme-toggle'
+import { AppStatsHeader } from '@/components/molecules/app-stats-header'
 import { Button } from '@/components/ui/button'
 import { pushRecent, readRecents, type RecentDomain } from '@/lib/recents'
 import { cn } from '@/lib/utils'
@@ -303,7 +304,7 @@ export function AppShell({
       ) : null}
 
       <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
-        <header className="flex h-12 shrink-0 items-center gap-2 border-b border-[color:var(--soft-border)] px-3 md:hidden">
+        <header className="flex h-12 shrink-0 items-center gap-2 border-b border-border px-3 md:hidden">
           <Button
             variant="ghost"
             size="icon-sm"
@@ -317,6 +318,9 @@ export function AppShell({
             <span className="font-mono text-[10px] text-primary">.sh</span>
           </Link>
         </header>
+
+        {/* Desktop + mobile: Redis-backed live platform stats */}
+        <AppStatsHeader />
 
         <main className="flex min-h-0 flex-1 flex-col overflow-hidden" id="main-content">
           {children}

--- a/components/organisms/app-shell.tsx
+++ b/components/organisms/app-shell.tsx
@@ -73,18 +73,18 @@ function SidebarBody({
         className="mb-2 flex items-baseline gap-0.5 rounded-lg px-2 py-1.5 outline-offset-4 transition-opacity hover:opacity-90"
         aria-label="designcontracts.sh home"
       >
-        <span className="font-serif text-[15px] tracking-tight text-sidebar-foreground">
+        <span className="text-[15px] font-normal tracking-tight text-sidebar-foreground">
           designcontracts
         </span>
-        <span className="font-mono text-[10px] text-muted-foreground">.sh</span>
+        <span className="font-mono text-[10px] text-primary">.sh</span>
       </Link>
 
       <Link
         href="/"
         onClick={onNavigate}
-        className="mb-2 inline-flex items-center gap-2 rounded-xl border border-sidebar-border bg-sidebar-accent/40 px-2.5 py-2 text-sm text-sidebar-foreground transition hover:bg-sidebar-accent"
+        className="mb-2 inline-flex items-center gap-2 rounded-lg bg-primary px-2.5 py-2 text-sm font-medium text-primary-foreground transition hover:bg-[var(--primary-active)]"
       >
-        <Plus className="size-3.5 opacity-80" aria-hidden />
+        <Plus className="size-3.5 opacity-90" aria-hidden />
         New chat
       </Link>
 
@@ -231,10 +231,12 @@ export function AppShell({
           <div className="flex h-full flex-col items-center gap-2 px-1.5 py-3">
             <Link
               href="/"
-              className="flex size-9 items-center justify-center rounded-lg font-serif text-sm text-sidebar-foreground hover:bg-sidebar-accent"
+              className="flex size-9 items-center justify-center rounded-lg text-sm font-normal text-sidebar-foreground hover:bg-sidebar-accent"
               aria-label="Chat"
             >
-              d
+              <span>
+                d<span className="text-primary">.</span>
+              </span>
             </Link>
             {PRIMARY_NAV.map((item) => {
               const Icon = item.icon
@@ -311,8 +313,8 @@ export function AppShell({
             {mobileOpen ? <X className="size-4" /> : <Menu className="size-4" />}
           </Button>
           <Link href="/" className="flex items-baseline gap-0.5">
-            <span className="font-serif text-base tracking-tight">designcontracts</span>
-            <span className="font-mono text-[10px] text-muted-foreground">.sh</span>
+            <span className="text-base font-normal tracking-tight">designcontracts</span>
+            <span className="font-mono text-[10px] text-primary">.sh</span>
           </Link>
         </header>
 

--- a/components/organisms/scan-results-layout.tsx
+++ b/components/organisms/scan-results-layout.tsx
@@ -182,37 +182,47 @@ export function ScanResultsLayout({
 
   if (error) {
     return (
-      <div className="mx-auto flex max-w-3xl flex-col items-start gap-4 px-6 py-16">
-        <p className="text-sm uppercase tracking-[0.2em] text-destructive/80">Scan failed</p>
-        <h2 className="font-serif text-3xl text-foreground">{error}</h2>
-        <Button onClick={onNewScan}>Try another URL</Button>
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <div className="mx-auto flex max-w-3xl flex-col items-start gap-4 px-4 py-12 sm:px-6">
+          <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-destructive">
+            Scan failed
+          </p>
+          <h2 className="font-serif text-3xl tracking-tight text-foreground">{error}</h2>
+          <div className="flex flex-wrap gap-2">
+            <Button onClick={onNewScan}>Try again</Button>
+            <Button variant="outline" onClick={() => (window.location.href = "/")}>
+              Back to Chat
+            </Button>
+          </div>
+        </div>
       </div>
     )
   }
 
   if (isLoading || !result) {
+    const pct = Math.min(
+      95,
+      ((progress?.step || 1) / (progress?.totalSteps || 5)) * 100
+    )
     return (
-      <div className="mx-auto flex max-w-3xl flex-col gap-6 px-6 py-16">
-        <div className="flex items-center gap-3 text-teal-800">
-          <Clock className="h-5 w-5 animate-spin" />
-          <p className="text-sm font-medium tracking-wide">
-            {progress?.message || "Scanning public CSS…"}
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <div className="mx-auto flex max-w-3xl flex-col gap-6 px-4 py-12 sm:px-6">
+          <div className="flex items-center gap-3 text-foreground">
+            <Clock className="size-4 animate-spin text-muted-foreground" />
+            <p className="text-sm font-medium tracking-tight">
+              {progress?.message || "Scanning public CSS…"}
+            </p>
+          </div>
+          <div className="h-1.5 overflow-hidden rounded-full bg-muted">
+            <div
+              className="h-full origin-left rounded-full bg-foreground transition-all duration-700"
+              style={{ width: `${pct}%` }}
+            />
+          </div>
+          <p className="text-sm text-muted-foreground">
+            Extracting tokens, layout DNA, and an installable Design Contract pack.
           </p>
         </div>
-        <div className="h-1.5 overflow-hidden rounded-full bg-slate-200">
-          <div
-            className="h-full origin-left rounded-full bg-teal-700 transition-all duration-700"
-            style={{
-              width: `${Math.min(
-                95,
-                ((progress?.step || 1) / (progress?.totalSteps || 5)) * 100
-              )}%`,
-            }}
-          />
-        </div>
-        <p className="text-sm text-muted-foreground">
-          Extracting tokens, layout DNA, DESIGN.md, and an agent skill — usually a few seconds.
-        </p>
       </div>
     )
   }
@@ -221,34 +231,25 @@ export function ScanResultsLayout({
   const families = result.curatedTokens?.typography?.families || []
 
   return (
-    <div className="mx-auto w-full max-w-6xl px-4 py-8 sm:px-6">
-      <header className="mb-8 flex flex-col gap-6 border-b border-border/60 pb-8 lg:flex-row lg:items-end lg:justify-between">
-        <div className="space-y-3">
+    <div className="min-h-0 flex-1 overflow-y-auto">
+      <div className="mx-auto w-full max-w-5xl px-4 py-8 sm:px-6 sm:py-10">
+      <header className="mb-8 flex flex-col gap-6 border-b border-border pb-8 lg:flex-row lg:items-end lg:justify-between">
+        <div className="flex flex-col gap-3">
           <div className="flex flex-wrap items-center gap-2">
-            <Badge variant="secondary" className="rounded-md">
-              {result.domain}
-            </Badge>
-            {result.cacheHit && (
-              <Badge variant="outline" className="rounded-md">
-                cached
-              </Badge>
-            )}
-            <Badge variant="outline" className="rounded-md">
-              {result.metadata?.engine || "w3c+design-md"}
+            <Badge variant="secondary">{result.domain}</Badge>
+            {result.cacheHit ? <Badge variant="outline">cached</Badge> : null}
+            <Badge variant="outline">
+              {result.metadata?.mode || result.metadata?.engine || "scan"}
             </Badge>
           </div>
-          <h2 className="font-serif text-3xl tracking-tight text-foreground sm:text-4xl">
-            Design Contract ready
-          </h2>
-          <p className="max-w-2xl text-sm text-muted-foreground sm:text-base">
+          <h1 className="font-serif text-3xl tracking-tight text-foreground sm:text-4xl">
+            {result.domain}
+          </h1>
+          <p className="max-w-2xl text-sm text-muted-foreground">
             {result.summary?.tokensExtracted || tokenCount} tokens ·{" "}
-            {Math.round(result.summary?.confidence || 0)}% confidence ·{" "}
-            {Math.round((result.summary?.processingTime || 0) / 100) / 10}s
+            {Math.round(result.summary?.confidence || 0)}% confidence
             {result.designContract
               ? ` · ${result.designContract.summary?.fileCount ?? 0} pack files`
-              : ""}
-            {result.semanticGraph
-              ? ` · ${result.semanticGraph.summary.nodeCount} graph nodes / ${result.semanticGraph.summary.edgeCount} edges`
               : ""}
             {result.brandAnalysis?.personality
               ? ` · ${result.brandAnalysis.personality}`
@@ -257,52 +258,53 @@ export function ScanResultsLayout({
         </div>
 
         <div className="flex flex-wrap gap-2">
-          {result.domain && (
+          {result.domain ? (
             <Button
-              variant="default"
               size="sm"
-              className="gap-2 bg-teal-800 hover:bg-teal-900"
               onClick={() => {
                 window.location.href = `/api/contracts/download?domain=${encodeURIComponent(result.domain!)}`
               }}
             >
-              <Download className="h-4 w-4" />
-              Download Design Contract
+              <Download data-icon="inline-start" />
+              Download pack
             </Button>
-          )}
-          {result.designMd && (
+          ) : null}
+          {result.designMd ? (
             <Button
               variant="outline"
               size="sm"
-              className="gap-2"
               onClick={() =>
                 downloadText(result.designMd!.fileName, result.designMd!.markdown)
               }
             >
-              <FileText className="h-4 w-4" />
-              DESIGN.md only
+              <FileText data-icon="inline-start" />
+              DESIGN.md
             </Button>
-          )}
-          {result.designSkill && (
+          ) : null}
+          {result.designSkill ? (
             <Button
               variant="outline"
               size="sm"
-              className="gap-2"
               onClick={() =>
                 downloadText("SKILL.md", result.designSkill!.markdown)
               }
             >
-              <Sparkles className="h-4 w-4" />
+              <Sparkles data-icon="inline-start" />
               Skill
             </Button>
-          )}
-          <Button variant="ghost" size="sm" className="gap-2" onClick={() => onExport("json")}>
+          ) : null}
+          <Button variant="ghost" size="sm" onClick={() => onExport("json")}>
             Tokens JSON
           </Button>
-          <Button variant="ghost" size="sm" className="gap-2" onClick={onShare}>
-            <Share2 className="h-4 w-4" />
+          <Button variant="ghost" size="sm" onClick={onShare}>
+            <Share2 data-icon="inline-start" />
             Share
           </Button>
+          {onNewScan ? (
+            <Button variant="ghost" size="sm" onClick={onNewScan}>
+              New scan
+            </Button>
+          ) : null}
         </div>
       </header>
 
@@ -338,7 +340,7 @@ export function ScanResultsLayout({
               <section className="rounded-2xl border border-[color:var(--soft-border)] bg-card/70 p-5 shadow-[var(--soft-shadow)]">
                 <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                   <div>
-                    <p className="text-xs uppercase tracking-[0.22em] text-teal-800/80 dark:text-teal-300/80">
+                    <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
                       Semantic design graph
                     </p>
                     <h3 className="mt-1 font-serif text-2xl tracking-tight">
@@ -397,7 +399,7 @@ export function ScanResultsLayout({
                       type="button"
                       title={color}
                       onClick={() => void copyText(color, color)}
-                      className="group relative h-16 w-16 overflow-hidden rounded-md border border-black/10 transition-transform hover:-translate-y-0.5"
+                      className="group relative size-14 overflow-hidden rounded-lg border border-border transition-transform hover:-translate-y-0.5"
                       style={{ background: color }}
                     >
                       <span className="absolute inset-x-0 bottom-0 bg-black/50 px-1 py-0.5 text-[10px] text-white opacity-0 transition-opacity group-hover:opacity-100">
@@ -572,15 +574,16 @@ export function ScanResultsLayout({
         )}
 
         {activeTab === "layout" && (
-          <div className="animate-fade-in space-y-4">
+          <div className="animate-fade-in flex flex-col gap-4">
             <p className="text-sm text-muted-foreground">
               Layout DNA inferred from collected CSS (containers, breakpoints, grid/flex mix, archetypes).
             </p>
-            <pre className="overflow-auto rounded-md border border-border/70 bg-slate-950 p-4 text-xs leading-relaxed text-slate-100">
+            <pre className="overflow-auto rounded-xl border border-border bg-muted/40 p-4 font-mono text-xs leading-relaxed text-foreground">
               {JSON.stringify(result.layoutDNA ?? {}, null, 2)}
             </pre>
           </div>
         )}
+      </div>
       </div>
     </div>
   )
@@ -618,9 +621,9 @@ function ArtifactCard({
     <div className="border-t border-border/70 pt-4">
       <div className="mb-2 flex items-center gap-2">
         {ready ? (
-          <CheckCircle2 className="h-4 w-4 text-teal-700" />
+          <CheckCircle2 className="size-4 text-foreground" />
         ) : (
-          <Clock className="h-4 w-4 text-muted-foreground" />
+          <Clock className="size-4 text-muted-foreground" />
         )}
         <h3 className="font-medium text-foreground">{title}</h3>
       </div>
@@ -629,8 +632,8 @@ function ArtifactCard({
         <Button size="sm" variant="outline" onClick={onOpen} disabled={!ready}>
           {openLabel}
         </Button>
-        <Button size="sm" variant="ghost" className="gap-1" onClick={onCopy} disabled={!ready}>
-          <Copy className="h-3.5 w-3.5" />
+        <Button size="sm" variant="ghost" onClick={onCopy} disabled={!ready}>
+          <Copy data-icon="inline-start" />
           {copied ? "Copied" : copyLabel}
         </Button>
       </div>
@@ -661,22 +664,17 @@ function MarkdownPanel({
           <p className="text-sm text-muted-foreground">{subtitle}</p>
         </div>
         <div className="flex gap-2">
-          <Button size="sm" variant="outline" className="gap-1" onClick={onCopy}>
-            <Copy className="h-3.5 w-3.5" />
+          <Button size="sm" variant="outline" onClick={onCopy}>
+            <Copy data-icon="inline-start" />
             {copied ? "Copied" : "Copy"}
           </Button>
-          <Button size="sm" className="gap-1 bg-teal-800 hover:bg-teal-900" onClick={onDownload}>
-            <Download className="h-3.5 w-3.5" />
+          <Button size="sm" onClick={onDownload}>
+            <Download data-icon="inline-start" />
             Download
           </Button>
         </div>
       </div>
-      <pre
-        className={cn(
-          "max-h-[70vh] overflow-auto rounded-md border border-border/70",
-          "bg-[#0B1220] p-5 text-[12px] leading-relaxed text-slate-100"
-        )}
-      >
+      <pre className="max-h-[70vh] overflow-auto rounded-xl border border-border bg-muted/40 p-5 font-mono text-xs leading-relaxed text-foreground">
         {markdown}
       </pre>
     </div>

--- a/components/organisms/scan-results-layout.tsx
+++ b/components/organisms/scan-results-layout.tsx
@@ -187,7 +187,7 @@ export function ScanResultsLayout({
           <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-destructive">
             Scan failed
           </p>
-          <h2 className="font-serif text-3xl tracking-tight text-foreground">{error}</h2>
+          <h2 className="font-normal tracking-tight text-3xl tracking-tight text-foreground">{error}</h2>
           <div className="flex flex-wrap gap-2">
             <Button onClick={onNewScan}>Try again</Button>
             <Button variant="outline" onClick={() => (window.location.href = "/")}>
@@ -242,7 +242,7 @@ export function ScanResultsLayout({
               {result.metadata?.mode || result.metadata?.engine || "scan"}
             </Badge>
           </div>
-          <h1 className="font-serif text-3xl tracking-tight text-foreground sm:text-4xl">
+          <h1 className="font-normal tracking-tight text-3xl tracking-tight text-foreground sm:text-4xl">
             {result.domain}
           </h1>
           <p className="max-w-2xl text-sm text-muted-foreground">
@@ -343,7 +343,7 @@ export function ScanResultsLayout({
                     <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
                       Semantic design graph
                     </p>
-                    <h3 className="mt-1 font-serif text-2xl tracking-tight">
+                    <h3 className="mt-1 font-normal tracking-tight text-2xl tracking-tight">
                       How the system links together
                     </h3>
                     <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
@@ -660,7 +660,7 @@ function MarkdownPanel({
     <div className="animate-fade-in space-y-4">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
         <div>
-          <h3 className="font-serif text-2xl text-foreground">{title}</h3>
+          <h3 className="font-normal tracking-tight text-2xl text-foreground">{title}</h3>
           <p className="text-sm text-muted-foreground">{subtitle}</p>
         </div>
         <div className="flex gap-2">

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -5,30 +5,31 @@ import { Slot } from "radix-ui"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "inline-flex shrink-0 items-center justify-center gap-1.5 whitespace-nowrap font-medium outline-none transition-[background-color,box-shadow,transform] duration-120 ease-out focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ui-focus)] disabled:pointer-events-none disabled:opacity-50 aria-invalid:outline-destructive [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5 active:translate-y-px",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-[var(--primary-active)]",
+        default:
+          "bg-[var(--ui-accent)] text-[var(--ui-paper)] shadow-[var(--shadow-control-primary)] hover:bg-[var(--ui-accent-hover)]",
         destructive:
-          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40",
+          "bg-[var(--ui-danger)] text-[var(--ui-paper)] shadow-[var(--shadow-control-primary)] hover:brightness-95",
         outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
+          "bg-[var(--ui-paper)] text-[var(--ui-ink)] shadow-[var(--shadow-control)] hover:bg-[var(--ui-paper-hover)] hover:shadow-[var(--shadow-control-hover)]",
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+          "bg-[var(--ui-paper-subtle)] text-[var(--ui-ink)] shadow-[var(--shadow-control)] hover:bg-[var(--ui-paper-hover)]",
         ghost:
-          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-        link: "text-primary underline-offset-4 hover:underline",
+          "bg-transparent text-[var(--ui-ink-secondary)] shadow-none hover:bg-[var(--ui-paper-hover)] hover:text-[var(--ui-ink)] active:translate-y-0",
+        link: "bg-transparent text-[var(--ui-accent)] shadow-none underline-offset-4 hover:underline active:translate-y-0",
       },
       size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        xs: "h-6 gap-1 rounded-md px-2 text-xs has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3",
-        sm: "h-8 gap-1.5 rounded-md px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
-        icon: "size-9",
-        "icon-xs": "size-6 rounded-md [&_svg:not([class*='size-'])]:size-3",
-        "icon-sm": "size-8",
-        "icon-lg": "size-10",
+        default: "h-8 min-h-8 rounded-[7px] px-2.5 text-[13px]",
+        xs: "h-7 min-h-7 gap-1 rounded-[7px] px-2 text-xs [&_svg:not([class*='size-'])]:size-3",
+        sm: "h-7 min-h-7 gap-1 rounded-[7px] px-2 text-xs",
+        lg: "h-9 min-h-9 rounded-[7px] px-3.5 text-sm",
+        icon: "size-8 min-h-8 rounded-[7px]",
+        "icon-xs": "size-7 min-h-7 rounded-[7px] [&_svg:not([class*='size-'])]:size-3",
+        "icon-sm": "size-7 min-h-7 rounded-[7px]",
+        "icon-lg": "size-9 min-h-9 rounded-[7px]",
       },
     },
     defaultVariants: {

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -9,7 +9,7 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default: "bg-primary text-primary-foreground hover:bg-[var(--primary-active)]",
         destructive:
           "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40",
         outline:

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "flex flex-col gap-4 rounded-[var(--radius-paper)] border border-[var(--ui-border)] bg-[var(--ui-paper)] py-4 text-[var(--ui-ink)] shadow-[var(--shadow-paper)]",
+        "flex flex-col gap-4 rounded-[var(--radius-paper)] border border-[var(--ui-border-soft)] bg-[var(--ui-paper)] py-4 text-[var(--ui-ink)] shadow-[var(--shadow-paper)]",
         className
       )}
       {...props}

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        "flex flex-col gap-4 rounded-[var(--radius-paper)] border border-[var(--ui-border)] bg-[var(--ui-paper)] py-4 text-[var(--ui-ink)] shadow-[var(--shadow-paper)]",
         className
       )}
       {...props}

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -8,9 +8,10 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:bg-input/30",
-        "focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
-        "aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
+        "h-8 w-full min-w-0 rounded-[7px] border-0 bg-[var(--ui-paper)] px-2.5 py-1 text-[13px] text-[var(--ui-ink)] shadow-[var(--shadow-control)] outline-none transition-[background-color,box-shadow] duration-120 selection:bg-[var(--ui-accent-soft)] selection:text-[var(--ui-ink)] file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-[13px] file:font-medium file:text-foreground placeholder:text-[var(--ui-ink-muted)] disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
+        "hover:bg-[var(--ui-paper-hover)] hover:shadow-[var(--shadow-control-hover)]",
+        "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ui-focus)]",
+        "aria-invalid:outline-[var(--ui-danger)]",
         className
       )}
       {...props}

--- a/hooks/use-theme.ts
+++ b/hooks/use-theme.ts
@@ -4,15 +4,17 @@ import { useEffect, useState } from 'react'
 
 export type Theme = 'light' | 'dark' | 'system'
 
+const DEFAULT_THEME: Theme = 'dark'
+
 function readStoredTheme(): Theme {
-  if (typeof window === 'undefined') return 'light'
+  if (typeof window === 'undefined') return DEFAULT_THEME
   try {
     const stored = localStorage.getItem('theme') as Theme | null
     if (stored && ['light', 'dark', 'system'].includes(stored)) return stored
   } catch {
     /* ignore */
   }
-  return 'light'
+  return DEFAULT_THEME
 }
 
 function applyTheme(theme: Theme) {
@@ -24,11 +26,18 @@ function applyTheme(theme: Theme) {
   root.classList.remove('light', 'dark')
   root.classList.add(actualTheme)
   root.style.colorScheme = actualTheme
+
+  // Keep browser chrome in sync
+  const meta = document.querySelector('meta[name="theme-color"]:not([media])')
+  if (meta) {
+    meta.setAttribute('content', actualTheme === 'dark' ? '#161310' : '#f3eee5')
+  }
 }
 
 export function useTheme() {
-  // Cream-first product — Cursor editorial calm by default
-  const [theme, setThemeState] = useState<Theme>(readStoredTheme)
+  const [theme, setThemeState] = useState<Theme>(DEFAULT_THEME)
+  const [resolved, setResolved] = useState<'light' | 'dark'>('dark')
+  const [mounted, setMounted] = useState(false)
 
   const setTheme = (next: Theme) => {
     setThemeState(next)
@@ -38,20 +47,34 @@ export function useTheme() {
       /* ignore */
     }
     applyTheme(next)
+    const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches
+      ? 'dark'
+      : 'light'
+    setResolved(next === 'system' ? systemTheme : next)
   }
 
   useEffect(() => {
-    applyTheme(theme)
-  }, [theme])
+    const stored = readStoredTheme()
+    setThemeState(stored)
+    applyTheme(stored)
+    const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches
+      ? 'dark'
+      : 'light'
+    setResolved(stored === 'system' ? systemTheme : stored)
+    setMounted(true)
+  }, [])
 
   useEffect(() => {
-    if (theme !== 'system') return
+    if (!mounted || theme !== 'system') return
 
     const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
-    const handleChange = () => applyTheme('system')
+    const handleChange = () => {
+      applyTheme('system')
+      setResolved(mediaQuery.matches ? 'dark' : 'light')
+    }
     mediaQuery.addEventListener('change', handleChange)
     return () => mediaQuery.removeEventListener('change', handleChange)
-  }, [theme])
+  }, [theme, mounted])
 
-  return { theme, setTheme }
+  return { theme, setTheme, resolved, mounted }
 }

--- a/hooks/use-theme.ts
+++ b/hooks/use-theme.ts
@@ -1,39 +1,39 @@
-"use client"
+'use client'
 
-import { useEffect, useState } from "react"
+import { useEffect, useState } from 'react'
 
-export type Theme = "light" | "dark" | "system"
+export type Theme = 'light' | 'dark' | 'system'
 
 function readStoredTheme(): Theme {
-  if (typeof window === "undefined") return "dark"
+  if (typeof window === 'undefined') return 'light'
   try {
-    const stored = localStorage.getItem("theme") as Theme | null
-    if (stored && ["light", "dark", "system"].includes(stored)) return stored
+    const stored = localStorage.getItem('theme') as Theme | null
+    if (stored && ['light', 'dark', 'system'].includes(stored)) return stored
   } catch {
     /* ignore */
   }
-  return "dark"
+  return 'light'
 }
 
 function applyTheme(theme: Theme) {
   const root = document.documentElement
-  const systemTheme = window.matchMedia("(prefers-color-scheme: dark)").matches
-    ? "dark"
-    : "light"
-  const actualTheme = theme === "system" ? systemTheme : theme
-  root.classList.remove("light", "dark")
+  const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches
+    ? 'dark'
+    : 'light'
+  const actualTheme = theme === 'system' ? systemTheme : theme
+  root.classList.remove('light', 'dark')
   root.classList.add(actualTheme)
   root.style.colorScheme = actualTheme
 }
 
 export function useTheme() {
-  // Dark-first product — Vercel/Cursor density by default
+  // Cream-first product — Cursor editorial calm by default
   const [theme, setThemeState] = useState<Theme>(readStoredTheme)
 
   const setTheme = (next: Theme) => {
     setThemeState(next)
     try {
-      localStorage.setItem("theme", next)
+      localStorage.setItem('theme', next)
     } catch {
       /* ignore */
     }
@@ -45,12 +45,12 @@ export function useTheme() {
   }, [theme])
 
   useEffect(() => {
-    if (theme !== "system") return
+    if (theme !== 'system') return
 
-    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)")
-    const handleChange = () => applyTheme("system")
-    mediaQuery.addEventListener("change", handleChange)
-    return () => mediaQuery.removeEventListener("change", handleChange)
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+    const handleChange = () => applyTheme('system')
+    mediaQuery.addEventListener('change', handleChange)
+    return () => mediaQuery.removeEventListener('change', handleChange)
   }, [theme])
 
   return { theme, setTheme }

--- a/lib/agent/tools.ts
+++ b/lib/agent/tools.ts
@@ -72,6 +72,9 @@ export const designContractTools = {
         force,
       })
 
+      const { trackStatEvent } = await import('@/lib/storage/platform-stats')
+      void trackStatEvent('agent_scan')
+
       return {
         status: result.cacheHit ? 'cached' : 'fresh',
         domain: result.domain,

--- a/lib/analytics/track-client.ts
+++ b/lib/analytics/track-client.ts
@@ -1,0 +1,20 @@
+'use client'
+
+import type { StatEvent } from '@/lib/storage/platform-stats'
+
+/** Fire-and-forget client telemetry into Redis-backed /api/stats/track */
+export function trackClientEvent(event: StatEvent): void {
+  if (typeof window === 'undefined') return
+  try {
+    void fetch('/api/stats/track', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ event }),
+      keepalive: true,
+    }).catch(() => {
+      /* ignore */
+    })
+  } catch {
+    /* ignore */
+  }
+}

--- a/lib/analytics/track-client.ts
+++ b/lib/analytics/track-client.ts
@@ -2,14 +2,33 @@
 
 import type { StatEvent } from '@/lib/storage/platform-stats'
 
+/** Browser event so the header can optimistic-bump before Redis round-trip */
+export const STATS_BUMP_EVENT = 'contextds:stats-bump'
+
+export type StatsBumpDetail = {
+  event: StatEvent
+  by?: number
+}
+
 /** Fire-and-forget client telemetry into Redis-backed /api/stats/track */
-export function trackClientEvent(event: StatEvent): void {
+export function trackClientEvent(event: StatEvent, by = 1): void {
   if (typeof window === 'undefined') return
+
+  try {
+    window.dispatchEvent(
+      new CustomEvent<StatsBumpDetail>(STATS_BUMP_EVENT, {
+        detail: { event, by },
+      })
+    )
+  } catch {
+    /* ignore */
+  }
+
   try {
     void fetch('/api/stats/track', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ event }),
+      body: JSON.stringify({ event, by }),
       keepalive: true,
     }).catch(() => {
       /* ignore */

--- a/lib/site-handoff.ts
+++ b/lib/site-handoff.ts
@@ -1,0 +1,151 @@
+/**
+ * Client-side handoff so Chat "Open" can show a contract even when
+ * Blob/Redis persistence briefly misses (or preview deploys lack Redis).
+ */
+
+import type { ScanWidgetPayload } from '@/components/molecules/scan-result-widget'
+import type { ScanResult } from '@/stores/scan-store'
+
+const KEY = (domain: string) => `dc:site-handoff:${normalizeDomain(domain)}`
+
+export function normalizeDomain(domain: string): string {
+  return domain
+    .trim()
+    .toLowerCase()
+    .replace(/^https?:\/\//, '')
+    .replace(/^www\./, '')
+    .split('/')[0]!
+}
+
+export function stashSiteHandoff(domain: string, payload: ScanWidgetPayload): void {
+  if (typeof window === 'undefined') return
+  try {
+    sessionStorage.setItem(
+      KEY(domain),
+      JSON.stringify({
+        savedAt: Date.now(),
+        payload,
+      })
+    )
+  } catch {
+    // quota / private mode — ignore
+  }
+}
+
+export function readSiteHandoff(domain: string): ScanWidgetPayload | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const raw = sessionStorage.getItem(KEY(domain))
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as { savedAt?: number; payload?: ScanWidgetPayload }
+    if (!parsed.payload?.domain) return null
+    // Discard stale handoffs (> 2h)
+    if (parsed.savedAt && Date.now() - parsed.savedAt > 2 * 60 * 60 * 1000) {
+      sessionStorage.removeItem(KEY(domain))
+      return null
+    }
+    return parsed.payload
+  } catch {
+    return null
+  }
+}
+
+/** Best-effort ScanResult from the chat widget payload (partial OK). */
+export function handoffToScanResult(payload: ScanWidgetPayload): ScanResult | null {
+  const domain = payload.domain ? normalizeDomain(payload.domain) : null
+  if (!domain) return null
+
+  const curatedCount = payload.summary?.curatedCount
+  const colors = payload.tokens?.colors ?? []
+  const families = payload.tokens?.typography?.families ?? []
+
+  return {
+    status: payload.status === 'failed' ? 'failed' : 'completed',
+    domain,
+    summary: {
+      tokensExtracted: payload.summary?.tokensExtracted ?? colors.length + families.length,
+      curatedCount: curatedCount
+        ? {
+            colors: Number(curatedCount.colors ?? colors.length) || 0,
+            fonts: Number(curatedCount.fonts ?? families.length) || 0,
+            sizes: Number(curatedCount.sizes ?? 0) || 0,
+            spacing: Number(curatedCount.spacing ?? 0) || 0,
+            radius: Number(curatedCount.radius ?? 0) || 0,
+            shadows: Number(curatedCount.shadows ?? 0) || 0,
+          }
+        : undefined,
+      confidence: payload.summary?.confidence ?? 0,
+      completeness: payload.summary?.completeness ?? 0,
+      reliability: 0,
+      processingTime: payload.summary?.processingTime ?? 0,
+    },
+    curatedTokens: {
+      colors,
+      typography: { families },
+    },
+    tokens: payload.tokens,
+    brandAnalysis: payload.brand
+      ? {
+          primaryColors: payload.brand.primaryColors,
+          personality: payload.brand.personality,
+          primaryFont: payload.brand.primaryFont,
+        }
+      : undefined,
+    designContract: payload.designContract
+      ? {
+          slug: domain,
+          title: payload.designContract.title ?? `${domain} Design Contract`,
+          profile: 'handoff',
+          installCommand: payload.designContract.installCommand ?? `npx designcontracts add ${domain}`,
+          summary: {
+            colorCount: payload.designContract.summary?.colorCount ?? colors.length,
+            typographyCount: payload.designContract.summary?.typographyCount ?? families.length,
+            spacingCount: 0,
+            fileCount: payload.designContract.summary?.fileCount ?? 0,
+          },
+        }
+      : undefined,
+    semanticGraph: payload.graph?.summary
+      ? {
+          schemaVersion: 1,
+          summary: {
+            nodeCount: payload.graph.summary.nodeCount ?? 0,
+            edgeCount: payload.graph.summary.edgeCount ?? 0,
+            tokenCount: 0,
+            roleCount: payload.graph.summary.roleCount ?? 0,
+            componentCount: payload.graph.summary.componentCount ?? 0,
+            layoutCount: 0,
+            patternCount: 0,
+          },
+          nodes: [],
+          edges: [],
+        }
+      : payload.graphSummary
+        ? {
+            schemaVersion: 1,
+            summary: {
+              nodeCount: payload.graphSummary.nodeCount ?? 0,
+              edgeCount: payload.graphSummary.edgeCount ?? 0,
+              tokenCount: 0,
+              roleCount: payload.graphSummary.roleCount ?? 0,
+              componentCount: payload.graphSummary.componentCount ?? 0,
+              layoutCount: 0,
+              patternCount: 0,
+            },
+            nodes: [],
+            edges: [],
+          }
+        : undefined,
+    screenshots: payload.screenshots?.map((s) => ({
+      label: s.label ?? 'homepage',
+      url: s.url,
+    })),
+    metadata: {
+      cssSources: 0,
+      mode: (payload.mode as 'fast' | 'accurate' | undefined) ?? 'fast',
+      engine: payload.browserEngine ?? 'design-contracts',
+      browserEngine: payload.browserEngine ?? undefined,
+    },
+    cacheHit: true,
+  }
+}

--- a/lib/storage/platform-stats.ts
+++ b/lib/storage/platform-stats.ts
@@ -1,0 +1,188 @@
+/**
+ * Redis-backed platform counters for Library / scans / product telemetry.
+ * Full scan payloads stay in Blob; this hash powers the header + /api/stats.
+ */
+
+import { Redis } from '@upstash/redis'
+
+export const STATS_HASH_KEY = 'contextds:stats'
+
+export type StatEvent =
+  | 'scan'
+  | 'cache_hit'
+  | 'cache_miss'
+  | 'library_view'
+  | 'contract_open'
+  | 'download'
+  | 'chat_message'
+  | 'agent_scan'
+
+export type PlatformCounters = {
+  sites: number
+  tokens: number
+  scans: number
+  cacheHits: number
+  cacheMisses: number
+  libraryViews: number
+  contractOpens: number
+  downloads: number
+  chatMessages: number
+  agentScans: number
+}
+
+const EVENT_TO_FIELD: Record<StatEvent, keyof PlatformCounters> = {
+  scan: 'scans',
+  cache_hit: 'cacheHits',
+  cache_miss: 'cacheMisses',
+  library_view: 'libraryViews',
+  contract_open: 'contractOpens',
+  download: 'downloads',
+  chat_message: 'chatMessages',
+  agent_scan: 'agentScans',
+}
+
+function getRedis(): Redis | null {
+  const url =
+    process.env.UPSTASH_REDIS_REST_URL || process.env.REDIS_URL || process.env.KV_REST_API_URL
+  const token =
+    process.env.UPSTASH_REDIS_REST_TOKEN || process.env.REDIS_TOKEN || process.env.KV_REST_API_TOKEN
+
+  if (!url || !token || !url.startsWith('https')) {
+    return null
+  }
+
+  return new Redis({ url, token })
+}
+
+export function isRedisConfigured(): boolean {
+  return Boolean(getRedis())
+}
+
+function toNumber(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && value.trim() !== '') {
+    const n = Number(value)
+    return Number.isFinite(n) ? n : 0
+  }
+  return 0
+}
+
+export function emptyCounters(): PlatformCounters {
+  return {
+    sites: 0,
+    tokens: 0,
+    scans: 0,
+    cacheHits: 0,
+    cacheMisses: 0,
+    libraryViews: 0,
+    contractOpens: 0,
+    downloads: 0,
+    chatMessages: 0,
+    agentScans: 0,
+  }
+}
+
+export async function readPlatformCounters(): Promise<PlatformCounters | null> {
+  const redis = getRedis()
+  if (!redis) return null
+
+  try {
+    const raw = await redis.hgetall<Record<string, string | number>>(STATS_HASH_KEY)
+    const base = emptyCounters()
+    if (!raw) return base
+
+    return {
+      sites: toNumber(raw.sites),
+      tokens: toNumber(raw.tokens),
+      scans: toNumber(raw.scans),
+      cacheHits: toNumber(raw.cacheHits),
+      cacheMisses: toNumber(raw.cacheMisses),
+      libraryViews: toNumber(raw.libraryViews),
+      contractOpens: toNumber(raw.contractOpens),
+      downloads: toNumber(raw.downloads),
+      chatMessages: toNumber(raw.chatMessages),
+      agentScans: toNumber(raw.agentScans),
+    }
+  } catch (error) {
+    console.warn('[platform-stats] read failed:', error)
+    return null
+  }
+}
+
+/** Atomically bump a single counter (events). */
+export async function trackStatEvent(event: StatEvent, by = 1): Promise<boolean> {
+  const redis = getRedis()
+  if (!redis) return false
+  const field = EVENT_TO_FIELD[event]
+  try {
+    await redis.hincrby(STATS_HASH_KEY, field, by)
+    return true
+  } catch (error) {
+    console.warn('[platform-stats] track failed:', error)
+    return false
+  }
+}
+
+/** Snapshot directory totals into Redis (sites / tokens / scans). */
+export async function writeDirectorySnapshot(snapshot: {
+  sites: number
+  tokens: number
+  scans: number
+}): Promise<boolean> {
+  const redis = getRedis()
+  if (!redis) return false
+  try {
+    await redis.hset(STATS_HASH_KEY, {
+      sites: String(snapshot.sites),
+      tokens: String(snapshot.tokens),
+      scans: String(snapshot.scans),
+      updatedAt: new Date().toISOString(),
+    })
+    return true
+  } catch (error) {
+    console.warn('[platform-stats] snapshot failed:', error)
+    return false
+  }
+}
+
+export function isStatEvent(value: unknown): value is StatEvent {
+  return typeof value === 'string' && value in EVENT_TO_FIELD
+}
+
+export type PlatformStatsSnapshot = PlatformCounters & {
+  updatedAt: string | null
+}
+
+/** Full Redis hash snapshot for /api/stats (counters + updatedAt). */
+export async function getPlatformStatsSnapshot(): Promise<PlatformStatsSnapshot> {
+  const redis = getRedis()
+  const base = emptyCounters()
+  if (!redis) {
+    return { ...base, updatedAt: null }
+  }
+
+  try {
+    const raw = await redis.hgetall<Record<string, string | number>>(STATS_HASH_KEY)
+    if (!raw) return { ...base, updatedAt: null }
+
+    return {
+      sites: toNumber(raw.sites),
+      tokens: toNumber(raw.tokens),
+      scans: toNumber(raw.scans),
+      cacheHits: toNumber(raw.cacheHits),
+      cacheMisses: toNumber(raw.cacheMisses),
+      libraryViews: toNumber(raw.libraryViews),
+      contractOpens: toNumber(raw.contractOpens),
+      downloads: toNumber(raw.downloads),
+      chatMessages: toNumber(raw.chatMessages),
+      agentScans: toNumber(raw.agentScans),
+      updatedAt:
+        typeof raw.updatedAt === 'string' && raw.updatedAt
+          ? raw.updatedAt
+          : null,
+    }
+  } catch (error) {
+    console.warn('[platform-stats] snapshot failed:', error)
+    return { ...base, updatedAt: null }
+  }
+}

--- a/lib/storage/serverless-store.ts
+++ b/lib/storage/serverless-store.ts
@@ -11,6 +11,11 @@
 
 import { Redis } from '@upstash/redis'
 import { del, get, list, put } from '@vercel/blob'
+import {
+  readPlatformCounters,
+  trackStatEvent,
+  writeDirectorySnapshot,
+} from '@/lib/storage/platform-stats'
 
 export interface SiteIndexEntry {
   id: string
@@ -124,7 +129,6 @@ const INDEX_BLOB_PATH = 'index/sites.json'
 const SITE_KEY = (domain: string) => `contextds:site:${normalizeDomain(domain)}`
 const RECENT_KEY = 'contextds:recent'
 const POPULAR_KEY = 'contextds:popular'
-const STATS_KEY = 'contextds:stats'
 
 function normalizeDomain(domain: string): string {
   return domain
@@ -272,12 +276,12 @@ async function saveDirectoryToBlob(sites: SiteIndexEntry[]): Promise<void> {
 function countTokens(tokens: unknown): number {
   if (!tokens || typeof tokens !== 'object') return 0
   const groups = tokens as Record<string, unknown>
-  return Object.values(groups).reduce((sum, value) => {
+  return Object.values(groups).reduce<number>((sum, value) => {
     if (Array.isArray(value)) return sum + value.length
     if (value && typeof value === 'object') {
       return (
         sum +
-        Object.values(value as Record<string, unknown>).reduce((inner, item) => {
+        Object.values(value as Record<string, unknown>).reduce<number>((inner, item) => {
           return inner + (Array.isArray(item) ? item.length : 0)
         }, 0)
       )
@@ -428,12 +432,17 @@ export async function saveScan(result: StoredScanResult): Promise<SiteIndexEntry
       redis.set(SITE_KEY(domain), site),
       redis.zadd(RECENT_KEY, { score: scannedAt, member: domain }),
       redis.zadd(POPULAR_KEY, { score: site.popularity, member: domain }),
-      redis.hincrby(STATS_KEY, 'scans', 1),
-      redis.hset(STATS_KEY, {
-        sites: String(await redis.zcard(POPULAR_KEY)),
-        tokens: String(tokenCount),
-      }),
     ])
+    // Keep header counters fresh in Redis
+    await trackStatEvent('scan', 1)
+    const allForSnap = await listSites({ sort: 'recent', limit: 500 })
+    const tokensTotal = allForSnap.reduce((sum, entry) => sum + entry.tokenCount, 0)
+    const scansTotal = allForSnap.reduce((sum, entry) => sum + entry.scanCount, 0)
+    await writeDirectorySnapshot({
+      sites: allForSnap.length,
+      tokens: tokensTotal,
+      scans: scansTotal,
+    })
   } else {
     const directory = await loadDirectoryFromBlob()
     const next = directory.filter((entry) => entry.domain !== domain)
@@ -497,6 +506,13 @@ export async function getDirectoryStats(): Promise<{
   tokenSets: number
   averageConfidence: number
   categories: Record<string, number>
+  cacheHits: number
+  cacheMisses: number
+  libraryViews: number
+  contractOpens: number
+  downloads: number
+  chatMessages: number
+  agentScans: number
   recentActivity: Array<{ domain: string; scannedAt: string | null; tokens: number }>
   popularSites: Array<{
     domain: string
@@ -505,18 +521,19 @@ export async function getDirectoryStats(): Promise<{
     lastScanned: string | null
   }>
 }> {
-  const recent = await listSites({ sort: 'recent', limit: 10 })
-  const popular = await listSites({ sort: 'popular', limit: 10 })
-  const all = await listSites({ sort: 'recent', limit: 500 })
+  const [recent, popular, all, counters] = await Promise.all([
+    listSites({ sort: 'recent', limit: 10 }),
+    listSites({ sort: 'popular', limit: 10 }),
+    listSites({ sort: 'recent', limit: 500 }),
+    readPlatformCounters(),
+  ])
 
-  const tokens = all.reduce((sum, site) => sum + site.tokenCount, 0)
-  const scans = all.reduce((sum, site) => sum + site.scanCount, 0)
+  const tokensFromDir = all.reduce((sum, site) => sum + site.tokenCount, 0)
+  const scansFromDir = all.reduce((sum, site) => sum + site.scanCount, 0)
   const withConfidence = all.filter((site) => typeof site.confidence === 'number')
   const averageConfidence = withConfidence.length
-    ? Math.round(
-        withConfidence.reduce((sum, site) => sum + (site.confidence ?? 0), 0) /
-          withConfidence.length
-      )
+    ? withConfidence.reduce((sum, site) => sum + (site.confidence ?? 0), 0) /
+      withConfidence.length
     : 0
 
   const categories = all.reduce(
@@ -533,13 +550,34 @@ export async function getDirectoryStats(): Promise<{
     { colors: 0, typography: 0, spacing: 0, shadows: 0, radius: 0, motion: 0 }
   )
 
+  // Prefer Redis snapshot when present; fall back to directory aggregation.
+  const sites = counters && counters.sites > 0 ? counters.sites : all.length
+  const tokens = counters && counters.tokens > 0 ? counters.tokens : tokensFromDir
+  const scans = counters && counters.scans > 0 ? counters.scans : scansFromDir
+
+  // Keep Redis snapshot warm when we have directory data but empty counters.
+  if (getRedis() && all.length > 0 && (!counters || counters.sites === 0)) {
+    void writeDirectorySnapshot({
+      sites: all.length,
+      tokens: tokensFromDir,
+      scans: scansFromDir,
+    })
+  }
+
   return {
-    sites: all.length,
+    sites,
     tokens,
     scans,
-    tokenSets: all.length,
+    tokenSets: sites,
     averageConfidence,
     categories,
+    cacheHits: counters?.cacheHits ?? 0,
+    cacheMisses: counters?.cacheMisses ?? 0,
+    libraryViews: counters?.libraryViews ?? 0,
+    contractOpens: counters?.contractOpens ?? 0,
+    downloads: counters?.downloads ?? 0,
+    chatMessages: counters?.chatMessages ?? 0,
+    agentScans: counters?.agentScans ?? 0,
     recentActivity: recent.map((site) => ({
       domain: site.domain,
       scannedAt: site.lastScanned,

--- a/lib/storage/serverless-store.ts
+++ b/lib/storage/serverless-store.ts
@@ -160,24 +160,66 @@ function createId(prefix: string): string {
   return `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`
 }
 
+type BlobAccess = 'public' | 'private'
+
+/**
+ * Cache which access mode works for this store.
+ * Private stores reject public puts; public stores reject private puts.
+ * Production Hobby blobs are often public — private-only writes silently failed
+ * and caused Open → /site to miss cache and re-scan forever.
+ */
+let resolvedBlobAccess: BlobAccess | null = null
+
+function preferredBlobAccessOrder(): BlobAccess[] {
+  const envAccess = process.env.BLOB_ACCESS
+  if (envAccess === 'public' || envAccess === 'private') {
+    return envAccess === 'public' ? ['public', 'private'] : ['private', 'public']
+  }
+  if (resolvedBlobAccess === 'public') return ['public', 'private']
+  if (resolvedBlobAccess === 'private') return ['private', 'public']
+  // Prefer private when possible; fall back for public stores.
+  return ['private', 'public']
+}
+
+function isWrongAccessError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+  return (
+    message.includes('public store') ||
+    message.includes('private store') ||
+    message.includes('private access') ||
+    message.includes('public access')
+  )
+}
+
 async function readBlobJson<T>(pathname: string): Promise<T | null> {
   if (!hasBlob()) return null
 
-  try {
-    // Prefer private get() — scan payloads are no longer world-readable.
-    const privateResult = await get(pathname, { access: 'private', useCache: false })
-    if (privateResult?.stream) {
-      const text = await new Response(privateResult.stream).text()
-      return JSON.parse(text) as T
+  // 1) Authenticated get (works for private stores; may 400 on public stores)
+  for (const access of preferredBlobAccessOrder()) {
+    try {
+      const result = await get(pathname, { access, useCache: false })
+      if (result?.stream) {
+        resolvedBlobAccess = access
+        const text = await new Response(result.stream).text()
+        return JSON.parse(text) as T
+      }
+    } catch (error) {
+      if (!isWrongAccessError(error)) {
+        // Continue to list/fetch fallback for missing/legacy blobs
+        break
+      }
     }
+  }
 
-    // Backward-compatible fallback for older public blobs
-    const { blobs } = await list({ prefix: pathname, limit: 1 })
+  // 2) Public URL via list (public stores + older uploads)
+  try {
+    const { blobs } = await list({ prefix: pathname, limit: 5 })
     const match = blobs.find((blob) => blob.pathname === pathname) ?? blobs[0]
     if (!match) return null
 
     const response = await fetch(match.url, { cache: 'no-store' })
     if (!response.ok) return null
+    resolvedBlobAccess = 'public'
     return (await response.json()) as T
   } catch (error) {
     console.warn('[serverless-store] blob read failed:', error)
@@ -188,18 +230,31 @@ async function readBlobJson<T>(pathname: string): Promise<T | null> {
 async function writeBlobJson(pathname: string, data: unknown): Promise<string | null> {
   if (!hasBlob()) return null
 
-  try {
-    const blob = await put(pathname, JSON.stringify(data), {
-      access: 'private',
-      contentType: 'application/json',
-      addRandomSuffix: false,
-      allowOverwrite: true,
-    })
-    return blob.url
-  } catch (error) {
-    console.warn('[serverless-store] blob write failed:', error)
-    return null
+  const body = JSON.stringify(data)
+  let lastError: unknown = null
+
+  for (const access of preferredBlobAccessOrder()) {
+    try {
+      const blob = await put(pathname, body, {
+        access,
+        contentType: 'application/json',
+        addRandomSuffix: false,
+        allowOverwrite: true,
+      })
+      resolvedBlobAccess = access
+      return blob.url
+    } catch (error) {
+      lastError = error
+      if (isWrongAccessError(error)) {
+        continue
+      }
+      console.warn('[serverless-store] blob write failed:', error)
+      return null
+    }
   }
+
+  console.warn('[serverless-store] blob write failed:', lastError)
+  return null
 }
 
 async function loadDirectoryFromBlob(): Promise<SiteIndexEntry[]> {

--- a/lib/workers/simple-scan.ts
+++ b/lib/workers/simple-scan.ts
@@ -25,6 +25,7 @@ import { type CssSource, collectStaticCss } from '@/lib/extractors/static-css'
 import { isBrowserServiceConfigured, scanWithBrowserService } from '@/lib/scanner/browser-service'
 import { analyzeWithWallace, mergeCuratedSets } from '@/lib/scanner/wallace-bridge'
 import { uploadScreenshot } from '@/lib/storage/blob-storage'
+import { trackStatEvent } from '@/lib/storage/platform-stats'
 import { getScan, type StoredScanResult, saveScan } from '@/lib/storage/serverless-store'
 import { ProgressEmitter } from '@/lib/workers/progress-emitter'
 
@@ -289,6 +290,7 @@ export async function runSimpleScan({
       if (ageMs < 24 * 60 * 60 * 1000 && sameMode) {
         const cachedResult = fromCache(cached)
         progress.complete({ domain, cacheHit: true })
+        void trackStatEvent('cache_hit')
         return cachedResult
       }
     }

--- a/stores/stats-store.ts
+++ b/stores/stats-store.ts
@@ -1,146 +1,86 @@
 import { create } from 'zustand'
-import { devtools } from 'zustand/middleware'
 
-export interface StatsData {
+export interface PlatformStats {
   sites: number
   tokens: number
+  avgConfidence: number
   scans: number
-  tokenSets: number
-  averageConfidence: number
-  categories: Record<string, number>
-  recentActivity: Array<{
-    domain: string | null
-    scannedAt: string | null
-    tokens: number
-  }>
-  popularSites: Array<{
-    domain: string | null
-    popularity: number | null
-    tokens: number
-    lastScanned: string | null
-  }>
+  cacheHits: number
+  cacheMisses: number
+  libraryViews: number
+  contractOpens: number
+  downloads: number
+  chatMessages: number
+  agentScans: number
+  lastUpdated: string
+  storage: {
+    redis: boolean
+    blob: boolean
+    mode: string
+  }
 }
 
 interface StatsState {
-  stats: StatsData | null
-  loading: boolean
+  stats: PlatformStats | null
+  isLoading: boolean
   error: string | null
-  lastUpdated: number | null
-  etag: string | null
-
-  // Actions
+  fetchStats: () => Promise<void>
+  /** @deprecated Use fetchStats */
   loadStats: () => Promise<void>
-  refreshStats: () => Promise<void>
-  setStats: (stats: StatsData) => void
+  startPolling: (intervalMs?: number) => () => void
 }
 
-export const useStatsStore = create<StatsState>()(
-  devtools(
-    (set, get) => ({
-      stats: null,
-      loading: false,
-      error: null,
-      lastUpdated: null,
-      etag: null,
+const EMPTY_STATS: PlatformStats = {
+  sites: 0,
+  tokens: 0,
+  avgConfidence: 0,
+  scans: 0,
+  cacheHits: 0,
+  cacheMisses: 0,
+  libraryViews: 0,
+  contractOpens: 0,
+  downloads: 0,
+  chatMessages: 0,
+  agentScans: 0,
+  lastUpdated: new Date(0).toISOString(),
+  storage: { redis: false, blob: false, mode: 'memory' },
+}
 
-      loadStats: async () => {
-        // Check loading state and set atomically
-        const currentState = get()
+export const useStatsStore = create<StatsState>((set, get) => {
+  const fetchStats = async () => {
+    if (get().isLoading) return
 
-        console.log('📊 [StatsStore] loadStats called', {
-          hasStats: !!currentState.stats,
-          loading: currentState.loading,
-          etag: currentState.etag
-        })
+    set({ isLoading: true, error: null })
 
-        // Skip if already loading
-        if (currentState.loading) {
-          console.log('⚠️ [StatsStore] Already loading, skipping')
-          return
-        }
+    try {
+      const response = await fetch('/api/stats', { cache: 'no-store' })
+      if (!response.ok) {
+        throw new Error('Failed to fetch stats')
+      }
 
-        set({ loading: true, error: null })
+      const data = (await response.json()) as PlatformStats
+      set({ stats: data, isLoading: false })
+    } catch (error) {
+      set({
+        error: error instanceof Error ? error.message : 'Unknown error',
+        isLoading: false,
+        stats: get().stats ?? EMPTY_STATS,
+      })
+    }
+  }
 
-        try {
-          // Get fresh state each time we need it
-          const { etag } = get()
-
-          // Use ETag for conditional requests (304 Not Modified)
-          const headers: HeadersInit = {}
-          if (etag) {
-            headers['If-None-Match'] = etag
-            console.log('🔖 [StatsStore] Using ETag:', etag)
-          }
-
-          console.log('🌐 [StatsStore] Fetching /api/stats')
-          const response = await fetch('/api/stats', { headers })
-          console.log('✅ [StatsStore] Response:', response.status, response.statusText)
-
-          // 304 Not Modified - data hasn't changed, use cached version
-          if (response.status === 304) {
-            // Get fresh state to check for stats
-            const { stats } = get()
-            if (stats) {
-              set({ loading: false })
-              return
-            }
-            // If no cached stats, treat as error and try without ETag
-            throw new Error('304 with no cached data')
-          }
-
-          if (!response.ok) throw new Error(`HTTP ${response.status}`)
-
-          const data = await response.json()
-          const newEtag = response.headers.get('etag')
-
-          // Atomic update
-          set({
-            stats: data,
-            loading: false,
-            lastUpdated: Date.now(),
-            etag: newEtag,
-            error: null // Clear any previous errors
-          })
-        } catch (error) {
-          set({
-            error: error instanceof Error ? error.message : 'Failed to load stats',
-            loading: false,
-          })
-        }
-      },
-
-      refreshStats: async () => {
-        // Force refresh (ignore ETag)
-        set({ loading: true, error: null })
-
-        try {
-          const response = await fetch('/api/stats')
-          if (!response.ok) throw new Error(`HTTP ${response.status}`)
-
-          const data = await response.json()
-          const newEtag = response.headers.get('etag')
-
-          set({
-            stats: data,
-            loading: false,
-            lastUpdated: Date.now(),
-            etag: newEtag,
-          })
-        } catch (error) {
-          set({
-            error: error instanceof Error ? error.message : 'Failed to load stats',
-            loading: false,
-          })
-        }
-      },
-
-      setStats: (stats) => {
-        set({
-          stats,
-          lastUpdated: Date.now(),
-        })
-      },
-    }),
-    { name: 'StatsStore' }
-  )
-)
+  return {
+    stats: null,
+    isLoading: false,
+    error: null,
+    fetchStats,
+    loadStats: fetchStats,
+    startPolling: (intervalMs = 15_000) => {
+      void get().fetchStats()
+      const id = window.setInterval(() => {
+        void get().fetchStats()
+      }, intervalMs)
+      return () => window.clearInterval(id)
+    },
+  }
+})

--- a/stores/stats-store.ts
+++ b/stores/stats-store.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import type { StatEvent } from '@/lib/storage/platform-stats'
 
 export interface PlatformStats {
   sites: number
@@ -24,10 +25,15 @@ interface StatsState {
   stats: PlatformStats | null
   isLoading: boolean
   error: string | null
+  /** Monotonic bump id — increments when any counter rises (drives pulse UI) */
+  bumpTick: number
+  lastBumpedFields: Array<keyof PlatformStats>
   fetchStats: () => Promise<void>
   /** @deprecated Use fetchStats */
   loadStats: () => Promise<void>
   startPolling: (intervalMs?: number) => () => void
+  /** Optimistic local increment before Redis confirms */
+  bumpEvent: (event: StatEvent, by?: number) => void
 }
 
 const EMPTY_STATS: PlatformStats = {
@@ -46,6 +52,37 @@ const EMPTY_STATS: PlatformStats = {
   storage: { redis: false, blob: false, mode: 'memory' },
 }
 
+const EVENT_TO_FIELD: Partial<Record<StatEvent, keyof PlatformStats>> = {
+  scan: 'scans',
+  cache_hit: 'cacheHits',
+  cache_miss: 'cacheMisses',
+  library_view: 'libraryViews',
+  contract_open: 'contractOpens',
+  download: 'downloads',
+  chat_message: 'chatMessages',
+  agent_scan: 'agentScans',
+}
+
+function risingFields(prev: PlatformStats | null, next: PlatformStats): Array<keyof PlatformStats> {
+  if (!prev) return []
+  const keys: Array<keyof PlatformStats> = [
+    'sites',
+    'tokens',
+    'scans',
+    'cacheHits',
+    'libraryViews',
+    'contractOpens',
+    'downloads',
+    'chatMessages',
+    'agentScans',
+  ]
+  return keys.filter((key) => {
+    const a = prev[key]
+    const b = next[key]
+    return typeof a === 'number' && typeof b === 'number' && b > a
+  })
+}
+
 export const useStatsStore = create<StatsState>((set, get) => {
   const fetchStats = async () => {
     if (get().isLoading) return
@@ -59,7 +96,39 @@ export const useStatsStore = create<StatsState>((set, get) => {
       }
 
       const data = (await response.json()) as PlatformStats
-      set({ stats: data, isLoading: false })
+      const prev = get().stats
+      const rose = risingFields(prev, data)
+
+      // Never let a poll wipe an optimistic bump that raced ahead of Redis
+      const merged: PlatformStats = prev
+        ? {
+            ...data,
+            sites: Math.max(prev.sites, data.sites),
+            tokens: Math.max(prev.tokens, data.tokens),
+            scans: Math.max(prev.scans, data.scans),
+            cacheHits: Math.max(prev.cacheHits, data.cacheHits),
+            cacheMisses: Math.max(prev.cacheMisses, data.cacheMisses),
+            libraryViews: Math.max(prev.libraryViews, data.libraryViews),
+            contractOpens: Math.max(prev.contractOpens, data.contractOpens),
+            downloads: Math.max(prev.downloads, data.downloads),
+            chatMessages: Math.max(prev.chatMessages, data.chatMessages),
+            agentScans: Math.max(prev.agentScans, data.agentScans),
+          }
+        : data
+
+      set({
+        stats: merged,
+        isLoading: false,
+        ...(rose.length
+          ? { bumpTick: get().bumpTick + 1, lastBumpedFields: rose }
+          : { lastBumpedFields: [] }),
+      })
+
+      if (rose.length && typeof window !== 'undefined') {
+        window.setTimeout(() => {
+          set({ lastBumpedFields: [] })
+        }, 1200)
+      }
     } catch (error) {
       set({
         error: error instanceof Error ? error.message : 'Unknown error',
@@ -73,9 +142,28 @@ export const useStatsStore = create<StatsState>((set, get) => {
     stats: null,
     isLoading: false,
     error: null,
+    bumpTick: 0,
+    lastBumpedFields: [],
     fetchStats,
     loadStats: fetchStats,
-    startPolling: (intervalMs = 15_000) => {
+    bumpEvent: (event, by = 1) => {
+      const field = EVENT_TO_FIELD[event]
+      if (!field) return
+      const current = get().stats ?? { ...EMPTY_STATS, lastUpdated: new Date().toISOString() }
+      const nextValue = (typeof current[field] === 'number' ? (current[field] as number) : 0) + by
+      set({
+        stats: { ...current, [field]: nextValue },
+        bumpTick: get().bumpTick + 1,
+        lastBumpedFields: [field],
+      })
+      // Clear highlight after the tick animation settles
+      window.setTimeout(() => {
+        if (get().lastBumpedFields.includes(field)) {
+          set({ lastBumpedFields: get().lastBumpedFields.filter((f) => f !== field) })
+        }
+      }, 1200)
+    },
+    startPolling: (intervalMs = 4_000) => {
       void get().fetchStats()
       const id = window.setInterval(() => {
         void get().fetchStats()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Completes the app-shell design system across **all public pages**, not only Chat / Library / Docs / Site.

Secondary routes (`/features`, `/pricing`, `/about`, `/contact`, `/privacy`, `/terms`, `/metrics`, ultrafast demo) now use the same left sidebar + canvas chrome. Marketing header/footer forks are removed from those routes.

## Docs
- **`DESIGN.md`** — full route table, More/legal sidebar map, `PageCanvas` rule
- **`AGENTS.md`** — cohesive routing rules; ban competing nav systems on public routes

## UI
- Sidebar **More**: Features · Pricing · About
- Compact legal links: Contact · Privacy · Terms
- New `PageCanvas` for scrollable content inside `AppShell`
- Quiet restyles for About / Pricing / Contact / Features (no blue hero / card soup)

## Routing cohesion
| Route | Nav |
|-------|-----|
| `/` | Chat |
| `/community` | Library |
| `/docs` | Docs |
| `/site/[domain]` | detail + Recents |
| `/features` `/pricing` `/about` | More |
| `/contact` `/privacy` `/terms` | legal links |

Base: `main` (prior shell work already landed as `4169a8c`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb424-02cd-75cc-ad48-89813fea64c0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb424-02cd-75cc-ad48-89813fea64c0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

